### PR TITLE
ref(Dockerfile): preferring non-Dockerfile env vars

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,6 +1,5 @@
 FROM alpine:3.3
 
-ENV WORKFLOW_MANAGER_API_PORT 8081
 EXPOSE 8081
 COPY . /
 CMD ["/usr/bin/workflow-manager-api"]


### PR DESCRIPTION
Because weird.
