### PR TITLE
ref(Dockerfile): absolute paths are for wimps

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -3,4 +3,4 @@ FROM alpine:3.3
 ENV WORKFLOW_MANAGER_API_PORT 8081
 EXPOSE 8081
 COPY . /
-CMD ["/usr/bin/workflow-manager-api"]
+CMD ["workflow-manager-api"]


### PR DESCRIPTION
we will assume "/usr/bin" is always in the PATH, and using an absolute path for execution makes it ever so slightly more likely that things will be break in the future if the target destination for the "workflow-manager-api" binary changes for any reason
