### PR TITLE
fix(debugging): we don't want to obfuscate data errors!

### DIFF
--- a/server.go
+++ b/server.go
@@ -23,7 +23,7 @@ var (
 func main() {
 	db := data.RDSDB{}
 	if err := data.VerifyPersistentStorage(db); err != nil {
-		log.Fatal("unable to verify persistent storage")
+		log.Fatalf("unable to verify persistent storage\n%s", err)
 	}
 	r := getRoutes(db, data.VersionFromDB{}, data.ClusterCount{}, data.ClusterFromDB{})
 	if err := http.ListenAndServe(":"+listenPort, r); err != nil {


### PR DESCRIPTION
It's definitive that "unable to verify persistent storage" is not enough information to debug the variety of possible error states in the `data.VerifyPersistentStorage` execution flow.
