### PR TITLE
fix(timestamp): time.Time type

### DIFF
--- a/data/timestamp.go
+++ b/data/timestamp.go
@@ -24,6 +24,9 @@ type Timestamp struct {
 // Scan is the Scanner interface implementation
 func (ts *Timestamp) Scan(value interface{}) error {
 	switch v := value.(type) {
+	case time.Time:
+		ts.Time = &v
+		return nil
 	case string:
 		t, err := time.Parse(stdTimestampFmt, v)
 		if err != nil {

--- a/data/timestamp_test.go
+++ b/data/timestamp_test.go
@@ -23,6 +23,7 @@ type timestampScanTestCase struct {
 func TestTimestampScan(t *testing.T) {
 	now := time.Now()
 	testCases := []timestampScanTestCase{
+		timestampScanTestCase{val: now, expectedTime: now, expectedErr: false},
 		timestampScanTestCase{val: now.Format(stdTimestampFmt), expectedTime: now, expectedErr: false},
 		timestampScanTestCase{val: []byte(now.Format(stdTimestampFmt)), expectedTime: now, expectedErr: false},
 		timestampScanTestCase{val: now.Format(time.ANSIC), expectedTime: now, expectedErr: true},


### PR DESCRIPTION
We're getting a time.Time type back from postgres for several columns, so we need to be ready to deal with it for our in-code`*Timestamp` field types. Tests updated.
