### PR TITLE
feat(data): versions handlers + data scaffolding

### DIFF
--- a/data/common_test.go
+++ b/data/common_test.go
@@ -5,6 +5,11 @@ const (
 	componentName        = "testcomponent"
 	componentDescription = "this is a component"
 	version              = "testversion"
-	released             = "testreleased"
+	train                = "stable"
+	released             = "2006-01-02T15:04:05Z"
 	updateAvailable      = "yup"
+)
+
+var (
+	versionData = []byte(`{}`)
 )

--- a/data/util.go
+++ b/data/util.go
@@ -14,3 +14,17 @@ func parseJSONComponent(jTxt sqlxTypes.JSONText) (types.ComponentVersion, error)
 	}
 	return *ret, nil
 }
+
+func parseDBVersions(versions []VersionsTable) ([]types.ComponentVersion, error) {
+	componentVersions := make([]types.ComponentVersion, len(versions))
+	for i, version := range versions {
+		versionData, err := version.data.MarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		component := types.Component{Name: version.componentName}
+		version := types.Version{Train: version.train, Version: version.version, Released: version.releaseTimestamp.String(), Data: versionData}
+		componentVersions[i] = types.ComponentVersion{Component: component, Version: version}
+	}
+	return componentVersions, nil
+}

--- a/data/util_test.go
+++ b/data/util_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/arschles/assert"
 	"github.com/deis/workflow-manager/types"
 	sqlxTypes "github.com/jmoiron/sqlx/types"
 )
@@ -19,7 +20,7 @@ func TestParseJSONComponentFail(t *testing.T) {
 func TestParseJSONComponentSucc(t *testing.T) {
 	cVer := types.ComponentVersion{
 		Component:       types.Component{Name: "test name", Description: "test description"},
-		Version:         types.Version{Version: "test version", Released: "test release"},
+		Version:         types.Version{Train: "stable", Version: "test version", Released: "test release", Data: []byte(`{}`)},
 		UpdateAvailable: "test update avail",
 	}
 	b, err := json.Marshal(cVer)
@@ -32,7 +33,5 @@ func TestParseJSONComponentSucc(t *testing.T) {
 	if err != nil {
 		t.Fatalf("returned error %s", err)
 	}
-	if parsedCVer != cVer {
-		t.Fatalf("old component version != new (%+v != %+v)", cVer, parsedCVer)
-	}
+	assert.Equal(t, parsedCVer, cVer, "component version")
 }

--- a/data/version_from_db_test.go
+++ b/data/version_from_db_test.go
@@ -1,7 +1,6 @@
 package data
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/arschles/assert"
@@ -17,22 +16,11 @@ func testComponentVersion() types.ComponentVersion {
 		Version: types.Version{
 			Version:  version,
 			Released: released,
+			Train:    train,
+			Data:     versionData,
 		},
 		UpdateAvailable: updateAvailable,
 	}
-}
-
-func cVerEqual(v1, v2 types.ComponentVersion) error {
-	if v1.Component.Name != v2.Component.Name {
-		return fmt.Errorf("component name %s != %s", v1.Component.Name, v2.Component.Name)
-	}
-	if v1.Component.Description != v2.Component.Description {
-		return fmt.Errorf("component description %s != %s", v1.Component.Description, v2.Component.Description)
-	}
-	if v1.Version.Version != v2.Version.Version {
-		return fmt.Errorf("version %s != %s", v1.Version.Version, v2.Version.Version)
-	}
-	return nil
 }
 
 func TestVersionFromDBRoundTrip(t *testing.T) {
@@ -44,14 +32,20 @@ func TestVersionFromDBRoundTrip(t *testing.T) {
 	assert.NotNil(t, db, "db")
 	assert.NoErr(t, err)
 	ver := VersionFromDB{}
-	cVerNoExist, err := ver.Get(sqliteDB, componentName)
+	componentVersion := testComponentVersion()
+	cVerNoExist, err := ver.Get(sqliteDB, componentVersion)
 	assert.True(t, err != nil, "error not returned but expected")
 	assert.Equal(t, cVerNoExist, types.ComponentVersion{}, "component version")
-	expectedCVer := testComponentVersion()
-	cVerSet, err := ver.Set(sqliteDB, componentName, expectedCVer)
+	cVerSet, err := ver.Set(sqliteDB, componentVersion)
 	assert.NoErr(t, err)
-	assert.NoErr(t, cVerEqual(cVerSet, expectedCVer))
-	getCVer, err := ver.Get(sqliteDB, componentName)
+	assert.Equal(t, cVerSet.Component.Name, componentVersion.Component.Name, "component name")
+	assert.Equal(t, cVerSet.Version.Version, componentVersion.Version.Version, "version string")
+	assert.Equal(t, cVerSet.Version.Released, componentVersion.Version.Released, "released string")
+	assert.Equal(t, cVerSet.Version.Train, componentVersion.Version.Train, "version train")
+	getCVer, err := ver.Get(sqliteDB, componentVersion)
 	assert.NoErr(t, err)
-	assert.NoErr(t, cVerEqual(getCVer, expectedCVer))
+	assert.Equal(t, getCVer.Component.Name, componentVersion.Component.Name, "component name")
+	assert.Equal(t, getCVer.Version.Version, componentVersion.Version.Version, "version string")
+	assert.Equal(t, getCVer.Version.Released, componentVersion.Version.Released, "released string")
+	assert.Equal(t, getCVer.Version.Train, componentVersion.Version.Train, "version train")
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,12 @@
 hash: 0a4b244a0a57f044a285064a483060b83cdead61511aa19e2a3fffaddd2921bd
-updated: 2016-03-21T15:56:18.40195291-07:00
+updated: 2016-04-19T10:38:19.04822411-07:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c
 - name: github.com/arschles/assert
   version: d21ecd4884be33397d1298c3738b2b4937c7f499
 - name: github.com/aws/aws-sdk-go
-  version: 4da0bec8953a0a540f391930a946917b12a95671
+  version: eb85a963838ae4ef2773c5b07f9e5bbf3865da46
   subpackages:
   - aws
   - aws/session
@@ -40,7 +40,7 @@ imports:
   subpackages:
   - spew
 - name: github.com/deis/workflow-manager
-  version: b37815165204e8a899ece414286fd8e7aba9f6f1
+  version: 6a7acfe9d13bb7c289d24e3f01b0029c10df0cec
   subpackages:
   - components
   - types
@@ -71,7 +71,7 @@ imports:
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-ini/ini
-  version: 776aa739ce9373377cd16f526cdf06cb4c89b40f
+  version: 12f418cc7edc5a618a51407b7ac1f1f512139df3
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/protobuf
@@ -102,7 +102,7 @@ imports:
 - name: github.com/google/gofuzz
   version: bbcb9da2d746f8bdbd6a936686a0a6067ada0ec5
 - name: github.com/gorilla/context
-  version: 215affda49addc4c8ef7e2534915df2c8c35c6cd
+  version: 1ea25387ff6f684839d82767c1733ff4d4d15d0a
 - name: github.com/gorilla/mux
   version: 0eeaf8392f5b04950925b8a69fe70f110fa7cbfc
 - name: github.com/jmespath/go-jmespath
@@ -116,7 +116,7 @@ imports:
 - name: github.com/kelseyhightower/envconfig
   version: cea086319492c3940683ea5e122aa5de70a33923
 - name: github.com/lib/pq
-  version: 165a3529e799da61ab10faed1fabff3662d6193f
+  version: 3cd0097429be7d611bb644ef85b42bfb102ceea4
   subpackages:
   - oid
 - name: github.com/matttproud/golang_protobuf_extensions
@@ -145,7 +145,7 @@ imports:
 - name: github.com/prometheus/procfs
   version: 490cc6eb5fa45bf8a8b7b73c8bc82a8160e8531d
 - name: github.com/satori/go.uuid
-  version: e673fdd4dea8a7334adbbe7f57b7e4b00bdc5502
+  version: f9ab0dce87d815821e221626b772e3475a0d2749
 - name: github.com/spf13/pflag
   version: 8e7dc108ab3a1ab6ce6d922bbaff5657b88e8e49
 - name: golang.org/x/crypto

--- a/server.go
+++ b/server.go
@@ -34,10 +34,12 @@ func main() {
 
 func getRoutes(db *sql.DB, version data.Version, count data.Count, cluster data.Cluster) *mux.Router {
 	r := mux.NewRouter()
-	r.HandleFunc("/{apiVersion}/versions/{component}", handlers.VersionsGetHandler(db, version)).Methods("GET")
-	r.HandleFunc("/{apiVersion}/versions/{component}", handlers.VersionsPostHandler(db, version)).Methods("POST")
-	r.HandleFunc("/{apiVersion}/clusters", handlers.ClustersHandler(db, count)).Methods("GET")
-	r.HandleFunc("/{apiVersion}/clusters/{id}", handlers.ClustersGetHandler(db, cluster)).Methods("GET")
-	r.HandleFunc("/{apiVersion}/clusters/{id}", handlers.ClustersPostHandler(db, cluster)).Methods("POST")
+	r.Handle("/{apiVersion}/versions/{train}/{component}/{version}", handlers.GetVersion(db, version)).Methods("GET")
+	r.Handle("/{apiVersion}/versions/{train}/{component}", handlers.GetComponentTrainVersions(db, version)).Methods("GET")
+	r.Handle("/{apiVersion}/versions/{train}/{component}/latest", handlers.GetLatestComponentTrainVersion(db, version)).Methods("GET")
+	r.Handle("/{apiVersion}/versions/{train}/{component}/{version}", handlers.PublishVersion(db, version)).Methods("POST")
+	r.Handle("/{apiVersion}/clusters/count", handlers.ClustersCount(db, count)).Methods("GET")
+	r.Handle("/{apiVersion}/clusters/{id}", handlers.GetCluster(db, cluster)).Methods("GET")
+	r.Handle("/{apiVersion}/clusters/{id}", handlers.ClusterCheckin(db, cluster)).Methods("POST")
 	return r
 }


### PR DESCRIPTION
This is the beginning of a full implementation of a deis component "Version" interface for workflow manager. There are changes to the initial "prototype" implementation of version, but it's probably best to approach this with the idea that this is the first full-fledged implementation.

Included:
- changes to the `versions` table schema
- `Version` interface now includes a `Get`, `Set`, `Collection`, and `Latest` method
  -- `Get`, `Set`, and `Collection` implementations are included in this PR
- convenience functions `data.getDBRecord` and `data.getDBRecords` now enables general purpose db record retrieval
- `newVersionDBRecord` and `updateVersionDBRecord` convenience functions fleshed out to reflect changes to `versions` table schema
- `data.parseDBVersions` convenience function added to convert an array (slice) of `versions` records from a DB into a `types.ComponentVersion` slice
- clusters count route changed to `/{apiVersion}/clusters/count`
  -- handler function changed to `handlers.ClustersCount`
- `handlers.ClustersGetHandler` changed to `handlers.GetCluster`
- `handlers.ClustersPostHandler` changed to `handlers.ClusterCheckin`
- `handlers.VersionsGetHandler` changed to `handlers.GetRelease`
- `handlers.VersionsPostHandler` changed to `handlers.PublishVersion`
- `handlers.GetComponentTrainVersions` and `handlers.GetLatestComponentTrainVersion` added to handle new `/{apiVersion}/versions/{train}/{component}` and `/{apiVersion}/versions/{train}/{component}/latest` routes, respectively
- tests updated for modified business logic and added for new stuff

Includes an updated glide.lock to scoop up recent changes to `github.com/deis/workflow-manager`
