### PR TITLE
ref(db): removed timestamp data fields from cluster table

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -17,8 +17,6 @@ Data is organized into three tables, with fields outlined below:
 
 * `clusters`, a table that stores "Cluster" records (each cluster record maps to a unique deis cluster seen in the wild)
   * `cluster_id uuid PRIMARY KEY`
-  * `first_seen timestamp`
-  * `last_seen timestamp DEFAULT current_timestamp`
   * `data json`
 * `clusters_checkins`, a table that stores records of deis clusters checking in with the API
   * `checkins_id bigserial PRIMARY KEY`

--- a/data/cluster_from_db_test.go
+++ b/data/cluster_from_db_test.go
@@ -2,7 +2,6 @@ package data
 
 import (
 	"testing"
-	"time"
 
 	"github.com/arschles/assert"
 	"github.com/deis/workflow-manager/types"
@@ -11,8 +10,6 @@ import (
 func testCluster() types.Cluster {
 	return types.Cluster{
 		ID:         clusterID,
-		FirstSeen:  time.Now(),
-		LastSeen:   time.Now().Add(1 * time.Hour),
 		Components: []types.ComponentVersion{testComponentVersion()},
 	}
 }


### PR DESCRIPTION
The clusters_checkins table will keep track of cluster registrations.

I have a PR in the workflow-manager repo that is related to this:

https://github.com/deis/workflow-manager/pull/28

`^----` that will permit clean JSON representations of types.Cluster w/out zero-value timestamp values.

This will require an out-of-band db update:

`ALTER TABLE clusters DROP COLUMN first_seen, DROP COLUMN last_seen;`
