### PR TITLE
feat(server.go,handlers): create multi-get-endpoint to get all latest releases

### DIFF
--- a/data/component_and_train.go
+++ b/data/component_and_train.go
@@ -1,0 +1,26 @@
+package data
+
+import (
+	"fmt"
+
+	"github.com/deis/workflow-manager/types"
+)
+
+// ComponentAndTrain represents a component and its train. It is used in functions such as
+// the Version interface's MultiLatest function, where the caller must specify each component
+// and its train at once.
+type ComponentAndTrain struct {
+	ComponentName string
+	Train         string
+}
+
+func componentAndTrainFromComponentVersion(cv types.ComponentVersion) *ComponentAndTrain {
+	return &ComponentAndTrain{
+		ComponentName: cv.Component.Name,
+		Train:         cv.Version.Train,
+	}
+}
+
+func (c ComponentAndTrain) String() string {
+	return fmt.Sprintf("%s (%s)", c.ComponentName, c.Train)
+}

--- a/data/version_from_db.go
+++ b/data/version_from_db.go
@@ -1,0 +1,68 @@
+package data
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/deis/workflow-manager/types"
+)
+
+// MultiLatest is the Version interface implementation
+func (c VersionFromDB) MultiLatest(db *sql.DB, ct []ComponentAndTrain) ([]types.ComponentVersion, error) {
+	componentsList := []string{}
+	listedComponents := make(map[string]struct{})
+	trainsList := []string{}
+	listedTrains := make(map[string]struct{})
+	for _, c := range ct {
+		if _, componentListed := listedComponents[c.ComponentName]; !componentListed {
+			componentsList = append(componentsList, fmt.Sprintf("'%s'", c.ComponentName))
+			listedComponents[c.ComponentName] = struct{}{}
+		}
+		if _, trainListed := listedTrains[c.Train]; !trainListed {
+			trainsList = append(trainsList, fmt.Sprintf("'%s'", c.Train))
+			listedTrains[c.Train] = struct{}{}
+		}
+	}
+	query := fmt.Sprintf(
+		"SELECT *, MAX(%s) FROM %s WHERE %s IN (%s) AND %s IN (%s) GROUP BY %s, %s",
+		versionsTableReleaseTimeStampKey,
+		versionsTableName,
+		versionsTableComponentNameKey,
+		strings.Join(componentsList, ","),
+		versionsTableTrainKey,
+		strings.Join(trainsList, ","),
+		versionsTableComponentNameKey,
+		versionsTableTrainKey,
+	)
+	rows, err := db.Query(query)
+	if err != nil {
+		return nil, err
+	}
+
+	rowsResult := []VersionsTable{}
+	defer rows.Close()
+	for rows.Next() {
+		var row VersionsTable
+		// note that we have to pass in a *sql.NullString as the first and last arg to ignore the
+		// primary key and the final release timestamp returned from the MAX aggregate function
+		// in the above SQL
+		if err = rows.Scan(
+			&sql.NullString{},
+			&row.componentName,
+			&row.train,
+			&row.version,
+			&row.releaseTimestamp,
+			&row.data,
+			&sql.NullString{},
+		); err != nil {
+			return nil, err
+		}
+		rowsResult = append(rowsResult, row)
+	}
+	componentVersions, err := parseDBVersions(rowsResult)
+	if err != nil {
+		return []types.ComponentVersion{}, err
+	}
+	return componentVersions, nil
+}

--- a/doc/api-architecture.md
+++ b/doc/api-architecture.md
@@ -114,7 +114,7 @@ Moreover, we will assume a more proximate relationship between the API and persi
   ```
 - Multi Get a collection of latest releases
   - Request type and URL
-    - `POST /:apiVersion/versions/latest` *not yet implemented*
+    - `POST /:apiVersion/versions/latest`
   - Request body
   ```
   {

--- a/get_latest_versions_test.go
+++ b/get_latest_versions_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/arschles/assert"
+	"github.com/deis/workflow-manager-api/data"
+	"github.com/deis/workflow-manager-api/handlers"
+	"github.com/deis/workflow-manager/types"
+)
+
+func TestGetLatestVersions(t *testing.T) {
+	memDB, err := data.NewMemDB()
+	assert.NoErr(t, err)
+	db, err := data.VerifyPersistentStorage(memDB)
+	assert.NoErr(t, err)
+	versionFromDB := data.VersionFromDB{}
+	srv := newServer(memDB, versionFromDB, data.ClusterCount{}, data.ClusterFromDB{})
+	defer srv.Close()
+	const numComponentVersions = 6
+	components := make(map[string]types.ComponentVersion)
+	for i := 0; i < numComponentVersions; i++ {
+		name := fmt.Sprintf("component%d", i)
+		train := fmt.Sprintf("train%d", i)
+		releaseTime1 := time.Now().Add(time.Duration(i+1) * time.Hour)
+		releaseTime2 := time.Now().Add(time.Duration((i+1)*2) * time.Hour)
+		cv1 := types.ComponentVersion{
+			Component: types.Component{Name: name},
+			Version: types.Version{
+				Train:    train,
+				Released: releaseTime1.Format(releaseTimeFormat),
+				Version:  fmt.Sprintf("version%d-1", i),
+			},
+		}
+		cv2 := types.ComponentVersion{
+			Component: types.Component{Name: name},
+			Version: types.Version{
+				Train:    train,
+				Released: releaseTime2.Format(releaseTimeFormat),
+				Version:  fmt.Sprintf("version%d-2", i),
+			},
+		}
+
+		if _, err := versionFromDB.Set(db, cv1); err != nil {
+			t.Fatalf("Error setting component %d (%s)", i, err)
+		}
+		if _, err := versionFromDB.Set(db, cv2); err != nil {
+			t.Fatalf("Error setting component %d (%s)", i, err)
+		}
+		components[cv2.Component.Name] = cv2
+	}
+
+	postBody := handlers.SparseComponentAndTrainInfoJSONWrapper{
+		Data: make([]handlers.SparseComponentAndTrainInfo, len(components)),
+	}
+	i := 0
+	for _, component := range components {
+		postBody.Data[i] = handlers.SparseComponentAndTrainInfo{
+			Component: handlers.SparseComponentInfo{Name: component.Component.Name},
+			Version:   handlers.SparseVersionInfo{Train: component.Version.Train},
+		}
+		i++
+	}
+	postBodyReader := new(bytes.Buffer)
+	assert.NoErr(t, json.NewEncoder(postBodyReader).Encode(postBody))
+
+	resp, err := httpPost(srv, urlPath(2, "versions", "latest"), string(postBodyReader.Bytes()))
+	assert.NoErr(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, resp.StatusCode, http.StatusOK, "response code")
+	respStruct := new(handlers.ComponentVersionsJSONWrapper)
+	assert.NoErr(t, json.NewDecoder(resp.Body).Decode(respStruct))
+	assert.Equal(t, len(respStruct.Data), len(components), "length of response")
+	for _, component := range respStruct.Data {
+		expected, ok := components[component.Component.Name]
+		assert.True(t, ok, "%s not found in the component/train response body", component.Component.Name)
+		assert.Equal(t, component.Version.Version, expected.Version.Version, "component version")
+		assert.Equal(t, component.Version.Train, expected.Version.Train, "component train")
+		assert.Equal(t, component.Version.Released, expected.Version.Released, "component released time")
+	}
+}

--- a/handlers/get_latest_versions.go
+++ b/handlers/get_latest_versions.go
@@ -1,0 +1,72 @@
+package handlers
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/deis/workflow-manager-api/data"
+	"github.com/deis/workflow-manager/types"
+)
+
+// SparseComponentInfo is the JSON compatible struct that holds limited data about a component
+type SparseComponentInfo struct {
+	Name string `json:"name"`
+}
+
+// SparseVersionInfo is the JSON compatible struct that holds limited data about a
+// component version
+type SparseVersionInfo struct {
+	Train string `json:"train"`
+}
+
+// SparseComponentAndTrainInfo is the JSON compatible struct that holds a
+// SparseComponentInfo and SparseVersionInfo
+type SparseComponentAndTrainInfo struct {
+	Component SparseComponentInfo `json:"component"`
+	Version   SparseVersionInfo   `json:"version"`
+}
+
+// SparseComponentAndTrainInfoJSONWrapper is the JSON compatible struct that holds a slice of
+// SparseComponentAndTrainInfo structs
+type SparseComponentAndTrainInfoJSONWrapper struct {
+	Data []SparseComponentAndTrainInfo `json:"data"`
+}
+
+// ComponentVersionsJSONWrapper is the JSON compatible struct that holds a slice of
+// types.ComponentVersion structs
+type ComponentVersionsJSONWrapper struct {
+	Data []types.ComponentVersion `json:"data"`
+}
+
+// GetLatestVersions is the handler for the POST /{apiVersion}/versions/latest endpoint
+func GetLatestVersions(db *sql.DB, versions data.Version) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqStruct := new(SparseComponentAndTrainInfoJSONWrapper)
+		if err := json.NewDecoder(r.Body).Decode(reqStruct); err != nil {
+			http.Error(w, fmt.Sprintf("error decoding request body (%s)", err), http.StatusBadRequest)
+			return
+		}
+
+		componentAndTrainSlice := make([]data.ComponentAndTrain, len(reqStruct.Data))
+		for i, d := range reqStruct.Data {
+			componentAndTrainSlice[i] = data.ComponentAndTrain{
+				ComponentName: d.Component.Name,
+				Train:         d.Version.Train,
+			}
+		}
+
+		componentVersions, err := versions.MultiLatest(db, componentAndTrainSlice)
+		if err != nil {
+			http.Error(w, "database error", http.StatusInternalServerError)
+			return
+		}
+
+		ret := ComponentVersionsJSONWrapper{Data: componentVersions}
+		if err := json.NewEncoder(w).Encode(ret); err != nil {
+			http.Error(w, "error encoding JSON", http.StatusInternalServerError)
+			return
+		}
+	})
+}

--- a/server.go
+++ b/server.go
@@ -34,11 +34,16 @@ func main() {
 
 func getRoutes(db *sql.DB, version data.Version, count data.Count, cluster data.Cluster) *mux.Router {
 	r := mux.NewRouter()
+	r.Handle("/{apiVersion}/versions/latest", handlers.GetLatestVersions(db, version)).Methods("POST").
+		Headers(handlers.ContentTypeHeaderKey, handlers.JSONContentType)
 	r.Handle("/{apiVersion}/versions/{train}/{component}", handlers.GetComponentTrainVersions(db, version)).Methods("GET")
+	// Note: the following route must go before the route that ends with {version}, so that
+	// Gorilla mux always routes the static "latest" route to the appropriate handler, and "latest"
+	// doesn't get interpreted as a {version}
 	r.Handle("/{apiVersion}/versions/{train}/{component}/latest", handlers.GetLatestComponentTrainVersion(db, version)).Methods("GET")
+	r.Handle("/{apiVersion}/versions/{train}/{component}/{version}", handlers.GetVersion(db, version)).Methods("GET")
 	r.Handle("/{apiVersion}/versions/{train}/{component}/{version}", handlers.PublishVersion(db, version)).Methods("POST").
 		Headers(handlers.ContentTypeHeaderKey, handlers.JSONContentType)
-	r.Handle("/{apiVersion}/versions/{train}/{component}/{version}", handlers.GetVersion(db, version)).Methods("GET")
 	r.Handle("/{apiVersion}/clusters/count", handlers.ClustersCount(db, count)).Methods("GET")
 	r.Handle("/{apiVersion}/clusters/{id}", handlers.GetCluster(db, cluster)).Methods("GET")
 	r.Handle("/{apiVersion}/clusters/{id}", handlers.ClusterCheckin(db, cluster)).Methods("POST").

--- a/server_test.go
+++ b/server_test.go
@@ -17,8 +17,9 @@ import (
 )
 
 const (
-	componentName = "testcomponent"
-	clusterID     = "testcluster"
+	componentName     = "testcomponent"
+	clusterID         = "testcluster"
+	releaseTimeFormat = "2006-01-02T15:04:05Z"
 )
 
 func newServer(d data.DB, ver data.Version, counter data.Count, cluster data.Cluster) *httptest.Server {
@@ -92,7 +93,6 @@ func TestGetComponentTrainVersions(t *testing.T) {
 func TestGetLatestComponentTrainVersion(t *testing.T) {
 	const componentName = "testcomponent"
 	const train = "testtrain"
-	const releaseTimeFormat = "2006-01-02T15:04:05Z"
 
 	memDB, err := data.NewMemDB()
 	assert.NoErr(t, err)
@@ -123,8 +123,7 @@ func TestGetLatestComponentTrainVersion(t *testing.T) {
 		componentVersions[i] = cv
 	}
 
-	// resp, err := httpGet(srv, urlPath(2, "versions", train, componentName, "latest"))
-	resp, err := httpGet(srv, fmt.Sprintf("v2/versions/%s/%s/latest", train, componentName))
+	resp, err := httpGet(srv, urlPath(2, "versions", train, componentName, "latest"))
 	assert.NoErr(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, resp.StatusCode, http.StatusOK, "response code")


### PR DESCRIPTION
Fixes #38
Contributes to #60 
Contributes to #58 
Contributes to #57

TODO:
- [x] write a test for the `POST /:apiVersion/versions/latest` endpoint in `server_test.go`
