### PR TITLE
feat(server.go,handlers/clusters_age_handler.go): design the cluster age REST API interface

### DIFF
--- a/data/cluster.go
+++ b/data/cluster.go
@@ -1,0 +1,15 @@
+package data
+
+import (
+	"database/sql"
+
+	"github.com/deis/workflow-manager/types"
+)
+
+// Cluster is an interface for managing a persistent cluster record
+type Cluster interface {
+	Get(*sql.DB, string) (types.Cluster, error)
+	Set(*sql.DB, string, types.Cluster) (types.Cluster, error)
+	Checkin(*sql.DB, string, types.Cluster) (sql.Result, error)
+	FilterByAge(*sql.DB, *ClusterAgeFilter) ([]types.Cluster, error)
+}

--- a/data/cluster_age_filter.go
+++ b/data/cluster_age_filter.go
@@ -1,0 +1,150 @@
+package data
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/deis/workflow-manager-api/rest"
+)
+
+type keyAndTime struct {
+	key  string
+	time time.Time
+}
+
+func (k keyAndTime) String() string {
+	return fmt.Sprintf("%s (%s)", k.key, k.time)
+}
+
+// ErrImpossibleFilter is the error returned when a caller tries to create a new ClusterAgeFilter
+// with parameters that would create a filter that is guaranteed to produce no results. One such
+// "impossible" query is a "created before" time is after a "created " time that is after  (i.e.
+// an impossible filter). See the documentation on ClusterAgeFilter for examples of impossible
+// filters
+type ErrImpossibleFilter struct {
+	vals   []keyAndTime
+	reason string
+}
+
+// Error is the error interface implementation
+func (e ErrImpossibleFilter) Error() string {
+	strs := make([]string, len(e.vals))
+	for i := 0; i < len(e.vals); i++ {
+		strs[i] = e.vals[i].String()
+	}
+	return fmt.Sprintf("impossible filter for keys/times (%s): %s", strings.Join(strs, ", "), e.reason)
+}
+
+// ClusterAgeFilter is the struct used to filter on cluster ages. It represents the conjunction
+// of all of its fields. For example:
+//
+//  created_time<=CreatedBefore
+//  AND
+//  created_time>=CreatedAfter
+//  AND
+//  checked_in_time<=CheckedInBefore
+//  AND
+//  checked_in_time>=CheckedInAfter
+type ClusterAgeFilter struct {
+	CheckedInBefore time.Time
+	CheckedInAfter  time.Time
+	CreatedBefore   time.Time
+	CreatedAfter    time.Time
+}
+
+// NewClusterAgeFilter returns a new ClusterAgeFilter if the given times can result in a valid
+// query that would return clusters. If not, returns nil and an ErrImpossibleFilter error
+func NewClusterAgeFilter(
+	checkedInBefore,
+	checkedInAfter,
+	createdBefore,
+	createdAfter time.Time,
+) (*ClusterAgeFilter, error) {
+	candidate := ClusterAgeFilter{
+		CheckedInBefore: checkedInBefore,
+		CheckedInAfter:  checkedInAfter,
+		CreatedBefore:   createdBefore,
+		CreatedAfter:    createdAfter,
+	}
+	if err := candidate.checkValid(); err != nil {
+		return nil, err
+	}
+	return &candidate, nil
+}
+
+func (c ClusterAgeFilter) checkValid() error {
+	if c.CreatedBefore.After(c.CheckedInBefore) {
+		// you can't have clusters that were checked in before they were created
+		return ErrImpossibleFilter{
+			vals: []keyAndTime{
+				keyAndTime{key: rest.CreatedBeforeQueryStringKey, time: c.CreatedBefore},
+				keyAndTime{key: rest.CheckedInBeforeQueryStringKey, time: c.CheckedInBefore},
+			},
+			reason: fmt.Sprintf(
+				"%s needs to be greater than or equal to %s",
+				rest.CheckedInBeforeQueryStringKey,
+				rest.CreatedBeforeQueryStringKey,
+			),
+		}
+	} else if c.CheckedInAfter.After(c.CheckedInBefore) || c.CheckedInAfter.Equal(c.CheckedInBefore) {
+		// you can't have clusters that were checked in before time T-1
+		// and at the same time checked in after time T+1
+		return ErrImpossibleFilter{
+			vals: []keyAndTime{
+				keyAndTime{key: rest.CheckedInBeforeQueryStringKey, time: c.CheckedInBefore},
+				keyAndTime{key: rest.CheckedInAfterQueryStringKey, time: c.CheckedInAfter},
+			},
+			reason: fmt.Sprintf(
+				"%s needs to be greater than %s",
+				rest.CheckedInBeforeQueryStringKey,
+				rest.CheckedInAfterQueryStringKey,
+			),
+		}
+	} else if c.CreatedAfter.After(c.CreatedBefore) || c.CreatedAfter.Equal(c.CreatedBefore) {
+		// you can't have clusters that were created after time T+1
+		// and at the same time created before time T-1
+		return ErrImpossibleFilter{
+			vals: []keyAndTime{
+				keyAndTime{key: rest.CreatedAfterQueryStringKey, time: c.CreatedAfter},
+				keyAndTime{key: rest.CreatedBeforeQueryStringKey, time: c.CreatedBefore},
+			},
+			reason: fmt.Sprintf(
+				"%s needs to be greater than %s",
+				rest.CreatedBeforeQueryStringKey,
+				rest.CreatedAfterQueryStringKey,
+			),
+		}
+	} else if c.CheckedInBefore.Before(c.CreatedAfter) || c.CheckedInBefore.Equal(c.CreatedAfter) {
+		// you can't have clusters that were checked in before time T-1
+		// and at the same time created after time T+1
+		return ErrImpossibleFilter{
+			vals: []keyAndTime{
+				keyAndTime{key: rest.CheckedInBeforeQueryStringKey, time: c.CheckedInBefore},
+				keyAndTime{key: rest.CreatedAfterQueryStringKey, time: c.CreatedAfter},
+			},
+			reason: fmt.Sprintf(
+				"%s needs to be after %s",
+				rest.CheckedInBeforeQueryStringKey,
+				rest.CreatedAfterQueryStringKey,
+			),
+		}
+	}
+	return nil
+}
+
+func (c ClusterAgeFilter) checkedInBeforeTimestamp() string {
+	return c.CheckedInBefore.Format(StdTimestampFmt)
+}
+
+func (c ClusterAgeFilter) checkedInAfterTimestamp() string {
+	return c.CheckedInAfter.Format(StdTimestampFmt)
+}
+
+func (c ClusterAgeFilter) createdBeforeTimestamp() string {
+	return c.CreatedBefore.Format(StdTimestampFmt)
+}
+
+func (c ClusterAgeFilter) createdAfterTimestamp() string {
+	return c.CreatedAfter.Format(StdTimestampFmt)
+}

--- a/data/cluster_age_filter_test.go
+++ b/data/cluster_age_filter_test.go
@@ -1,0 +1,48 @@
+package data
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewClusterAgeFilter(t *testing.T) {
+	type testCase struct {
+		chB time.Time
+		chA time.Time
+		crB time.Time
+		crA time.Time
+		err bool
+	}
+
+	testCases := []testCase{
+		// checked in time test cases
+		testCase{chB: timeNow(), chA: timeNow(), crB: timeFuture(), crA: timeNow(), err: true},
+		testCase{chB: timeNow(), chA: timeFuture(), crB: timeFuture(), crA: timeNow(), err: true},
+		testCase{chB: timePast(), chA: timeNow(), crB: timeFuture(), crA: timeNow(), err: true},
+		testCase{chB: timeFuture(), chA: timeNow(), crB: timeFuture(), crA: timeNow(), err: false},
+		// create time test cases
+		testCase{chB: timeFuture(), chA: timeNow(), crB: timeNow(), crA: timeNow(), err: true},
+		testCase{chB: timeFuture(), chA: timeNow(), crB: timeNow(), crA: timeFuture(), err: true},
+		testCase{chB: timeFuture(), chA: timeNow(), crB: timePast(), crA: timeNow(), err: true},
+		testCase{chB: timeFuture(), chA: timeNow(), crB: timeNow(), crA: timePast(), err: false},
+	}
+
+	for i, testCase := range testCases {
+		filter, err := NewClusterAgeFilter(testCase.chB, testCase.chA, testCase.crB, testCase.crA)
+		if testCase.err && err == nil {
+			t.Errorf("expected error on iteration %d but got none", i)
+			continue
+		} else if !testCase.err && err != nil {
+			t.Errorf("expected no error on iteration %d but got %s", i, err)
+			continue
+		}
+		if filter == nil && err == nil {
+			t.Errorf("got no error but resulting filter was nil on iteration %d", i)
+			continue
+		}
+		if filter != nil && err != nil {
+			t.Errorf("got an error but resulting filter was not nil on iteration %d", i)
+			continue
+		}
+	}
+}

--- a/data/cluster_from_db.go
+++ b/data/cluster_from_db.go
@@ -1,0 +1,119 @@
+package data
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/deis/workflow-manager/components"
+	"github.com/deis/workflow-manager/types"
+)
+
+// ClusterFromDB fulfills the Cluster interface
+type ClusterFromDB struct{}
+
+// Get method for ClusterFromDB, the actual database/sql.DB implementation
+func (c ClusterFromDB) Get(db *sql.DB, id string) (types.Cluster, error) {
+	row := getDBRecord(db, clustersTableName, []string{clustersTableIDKey}, []string{id})
+	rowResult := ClustersTable{}
+	if err := row.Scan(&rowResult.clusterID, &rowResult.data); err != nil {
+		return types.Cluster{}, err
+	}
+	cluster, err := components.ParseJSONCluster(rowResult.data)
+	if err != nil {
+		log.Println("error parsing cluster")
+		return types.Cluster{}, err
+	}
+	return cluster, nil
+}
+
+// Set method for ClusterFromDB, the actual database/sql.DB implementation
+func (c ClusterFromDB) Set(db *sql.DB, id string, cluster types.Cluster) (types.Cluster, error) {
+	var ret types.Cluster // return variable
+	js, err := json.Marshal(cluster)
+	if err != nil {
+		fmt.Println("error marshaling data")
+	}
+	row := getDBRecord(db, clustersTableName, []string{clustersTableIDKey}, []string{id})
+	var result sql.Result
+	// Register the "latest checkin" with the primary cluster record
+	rowResult := ClustersTable{}
+	if err := row.Scan(&rowResult.clusterID, &rowResult.data); err != nil {
+		result, err = newClusterDBRecord(db, id, js)
+		if err != nil {
+			log.Println(err)
+		}
+	} else {
+		result, err = updateClusterDBRecord(db, id, js)
+		if err != nil {
+			log.Println(err)
+		}
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		log.Println("failed to get affected row count")
+	}
+	if affected == 0 {
+		log.Println("no records updated")
+	} else if affected == 1 {
+		ret, err = c.Get(db, id)
+		if err != nil {
+			return types.Cluster{}, err
+		}
+	} else if affected > 1 {
+		log.Println("updated more than one record with same ID value!")
+	}
+	return ret, nil
+}
+
+// Checkin method for ClusterFromDB, the actual database/sql.DB implementation
+func (c ClusterFromDB) Checkin(db *sql.DB, id string, cluster types.Cluster) (sql.Result, error) {
+	js, err := json.Marshal(cluster)
+	if err != nil {
+		fmt.Println("error marshaling data")
+	}
+	result, err := newClusterCheckinsDBRecord(db, id, now(), js)
+	if err != nil {
+		log.Println("cluster checkin db record not created", err)
+		return nil, err
+	}
+	return result, nil
+}
+
+// FilterByAge returns a slice of clusters whose various time fields match the requirements
+// in the given filter. Note that the filter's requirements are a conjunction, not a disjunction
+func (c ClusterFromDB) FilterByAge(db *sql.DB, filter *ClusterAgeFilter) ([]types.Cluster, error) {
+	query := fmt.Sprintf(`SELECT DISTINCT clusters.*
+		FROM clusters, clusters_checkins
+		WHERE clusters_checkins.cluster_id = clusters.cluster_id
+		GROUP BY clusters_checkins.cluster_id
+		HAVING MIN(clusters_checkins.created_at) > '%s'
+		AND MIN(clusters_checkins.created_at) < '%s'
+		AND MIN(clusters_checkins.created_at) > '%s'
+		AND MAX(clusters_checkins.created_at) < '%s'`,
+		filter.createdAfterTimestamp(),
+		filter.createdBeforeTimestamp(),
+		filter.checkedInAfterTimestamp(),
+		filter.checkedInBeforeTimestamp(),
+	)
+
+	rows, err := db.Query(query)
+	if err != nil {
+		return nil, err
+	}
+
+	clusters := []types.Cluster{}
+	for rows.Next() {
+		rowResult := ClustersTable{}
+		if err := rows.Scan(&rowResult.clusterID, &rowResult.data); err != nil {
+			return nil, err
+		}
+		cluster, err := components.ParseJSONCluster(rowResult.data)
+		if err != nil {
+			return nil, err
+		}
+		clusters = append(clusters, cluster)
+	}
+	return clusters, nil
+}

--- a/data/cluster_from_db_filter_by_age_test.go
+++ b/data/cluster_from_db_filter_by_age_test.go
@@ -1,0 +1,200 @@
+package data
+
+import (
+	"database/sql"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/deis/workflow-manager/types"
+	"github.com/pborman/uuid"
+)
+
+var (
+	validClusterAgeFilter = ClusterAgeFilter{
+		CheckedInBefore: timeFuture().Add(2 * time.Hour),
+		CheckedInAfter:  timePast(),
+		CreatedAfter:    timePast().Add(-1 * time.Hour),
+		CreatedBefore:   timeFuture(),
+	}
+	validCreatedAtTime = timeNow()
+
+	invalidCreatedAtTimes = []time.Time{
+		// after the checked_in_before constraint
+		validClusterAgeFilter.CheckedInBefore.Add(1 * time.Hour),
+		// before the checked_in_after constraint
+		validClusterAgeFilter.CheckedInAfter.Add(-1 * time.Hour),
+		// before the created_after constraint
+		validClusterAgeFilter.CreatedAfter.Add(-1 * time.Hour),
+		// after the created_before constraint
+		validClusterAgeFilter.CreatedBefore.Add(1 * time.Hour),
+	}
+)
+
+func invalidClusterAgeFilters() []ClusterAgeFilter {
+	return []ClusterAgeFilter{
+		// created_before > checked_in_before
+		ClusterAgeFilter{
+			CreatedBefore:   timeNow(),
+			CreatedAfter:    timePast(),
+			CheckedInBefore: timePast(),
+			CheckedInAfter:  timePast().Add(-1 * time.Hour),
+		},
+		// checked_in_after > checked_in_before
+		ClusterAgeFilter{
+			CreatedBefore:   timeFuture(),
+			CreatedAfter:    timeNow(),
+			CheckedInBefore: timePast(),
+			CheckedInAfter:  timeNow(),
+		},
+		// checked_in_after == checked_in_before
+		ClusterAgeFilter{
+			CreatedBefore:   timeNow(),
+			CreatedAfter:    timePast(),
+			CheckedInBefore: timeFuture(),
+			CheckedInAfter:  timeFuture(),
+		},
+		// created_after > created_before
+		ClusterAgeFilter{
+			CreatedBefore:   timePast(),
+			CreatedAfter:    timeNow(),
+			CheckedInBefore: timeFuture().Add(1 * time.Hour),
+			CheckedInAfter:  timeFuture(),
+		},
+		// created_after == created_before
+		ClusterAgeFilter{
+			CreatedBefore:   timePast(),
+			CreatedAfter:    timePast(),
+			CheckedInBefore: timeFuture(),
+			CheckedInAfter:  timeNow(),
+		},
+		// checked_in_before < created_after
+		ClusterAgeFilter{
+			CreatedBefore:   timeFuture(),
+			CreatedAfter:    timeNow(),
+			CheckedInBefore: timePast(),
+			CheckedInAfter:  timePast().Add(-1 * time.Hour),
+		},
+		// checked_in_before == created_after
+		ClusterAgeFilter{
+			CreatedBefore:   timeFuture(),
+			CreatedAfter:    timeNow(),
+			CheckedInBefore: timeNow(),
+			CheckedInAfter:  timePast().Add(-1 * time.Hour),
+		},
+	}
+}
+
+type filterAndCreatedAt struct {
+	filter    ClusterAgeFilter // the filter to run queries with
+	createdAt time.Time        // the time to set in the created_at field of the cluster checkin
+	expected  bool             // whether or not results are expected to come back for the filter & created at time
+}
+
+func createFilters() []filterAndCreatedAt {
+	ret := []filterAndCreatedAt{
+		filterAndCreatedAt{
+			filter:    validClusterAgeFilter,
+			createdAt: validCreatedAtTime,
+			expected:  true,
+		},
+	}
+	for _, invalidCreatedAtTime := range invalidCreatedAtTimes {
+		ret = append(ret, filterAndCreatedAt{
+			filter:    validClusterAgeFilter,
+			createdAt: invalidCreatedAtTime,
+			expected:  false,
+		})
+	}
+	for _, filter := range invalidClusterAgeFilters() {
+		ret = append(ret, filterAndCreatedAt{
+			filter:    filter,
+			createdAt: validCreatedAtTime,
+			expected:  false,
+		})
+	}
+	return ret
+}
+
+func createCheckin(db *sql.DB, cl types.Cluster, createdAt *Timestamp) error {
+	data, err := json.Marshal(cl)
+	if err != nil {
+		return err
+	}
+	if _, err = newClusterCheckinsDBRecord(db, cl.ID, createdAt, data); err != nil {
+		return err
+	}
+	return nil
+}
+
+func TestClusterFromDBFilterByAge(t *testing.T) {
+	cluster := testCluster()
+	cluster.ID = uuid.New()
+
+	// generate all combinations of filters
+	filters := createFilters()
+
+	var wg sync.WaitGroup
+	for i, fca := range filters {
+		wg.Add(1)
+		go func(i int, fca filterAndCreatedAt) {
+			defer wg.Done()
+			// sanity check the filter so we don't get false negatives later on in the query
+			validErr := fca.filter.checkValid()
+			if validErr != nil && fca.expected {
+				t.Errorf("expected results for case %d but filter is invalid (%s)", i, validErr)
+				return
+			}
+
+			c := ClusterFromDB{}
+			db, err := newDB()
+			if err != nil {
+				t.Errorf("error creating new DB in case %d (%s)", i, err)
+				return
+			}
+
+			// create cluster in the DB
+			if _, setErr := c.Set(db, cluster.ID, cluster); setErr != nil {
+				t.Errorf("error creating cluster %s in DB (%s)", cluster.ID, setErr)
+				return
+			}
+
+			// check in the cluster
+			if cErr := createCheckin(db, cluster, &Timestamp{Time: &fca.createdAt}); cErr != nil {
+				t.Errorf("error creating checkin for case %d (%s)", i, cErr)
+				return
+			}
+
+			// filter the cluster & test results
+			filteredClusters, filterErr := c.FilterByAge(db, &fca.filter)
+			if filterErr != nil {
+				t.Errorf("error filtering for case %d (%s)", i, filterErr)
+				return
+			}
+			if fca.expected && len(filteredClusters) != 1 {
+				t.Errorf("expected %d filtered cluster(s) on filter %d, got %d", 1, i, len(filteredClusters))
+				return
+			} else if !fca.expected && len(filteredClusters) > 0 {
+				t.Errorf("expected 0 filtered clusters for filter %d, got %d", i, len(filteredClusters))
+				return
+			}
+
+			db, err = newDB()
+			if err != nil {
+				t.Errorf("error creating new DB in case %d (%s)", i, err)
+				return
+			}
+			filteredClusters, filterErr = c.FilterByAge(db, &fca.filter)
+			if filterErr != nil {
+				t.Errorf("error filtering for case %d (%s)", i, filterErr)
+				return
+			}
+			if len(filteredClusters) != 0 {
+				t.Errorf("expected 0 filtered clusters, got %d for case %d", len(filteredClusters), i)
+				return
+			}
+		}(i, fca)
+	}
+	wg.Wait()
+}

--- a/data/time_utils_test.go
+++ b/data/time_utils_test.go
@@ -1,0 +1,60 @@
+package data
+
+import (
+	"fmt"
+	"time"
+)
+
+var (
+	zeroTime   time.Time
+	nowTime    = time.Now()
+	futureTime = nowTime.Add(1 * time.Hour)
+	pastTime   = nowTime.Add(-1 * time.Hour)
+)
+
+func timeFuture() time.Time {
+	return futureTime
+}
+
+func timePast() time.Time {
+	return pastTime
+}
+
+func timeNow() time.Time {
+	return nowTime
+}
+
+type errNoPossibleBetweenTime struct {
+	lt time.Time
+	gt time.Time
+}
+
+func (e errNoPossibleBetweenTime) Error() string {
+	return fmt.Sprintf("no possible time between %s and %s", e.lt, e.gt)
+}
+
+// returns a time such that t1 < retval < t2. if that inequality is
+// impossible, returns the zero time and errNoPossibleBetweenTime
+func betweenTimes(t1, t2 time.Time) (time.Time, error) {
+	if t1.Before(t2) {
+		diff := t2.Sub(t1)
+		return t1.Add(diff / 2), nil
+	}
+	return zeroTime, errNoPossibleBetweenTime{lt: t1, gt: t2}
+}
+
+// returns a time that is less than both t1 and t2
+func lessThanTimes(t1, t2 time.Time) time.Time {
+	if t1.Before(t2) {
+		return t1.Add(-1 * time.Hour)
+	}
+	return t2.Add(-1 * time.Hour)
+}
+
+// returns a time that is greater than both t1 and t2
+func greaterThanTimes(t1, t2 time.Time) time.Time {
+	if t1.Before(t2) {
+		return t2.Add(1 * time.Hour)
+	}
+	return t1.Add(1 * time.Hour)
+}

--- a/data/timestamp.go
+++ b/data/timestamp.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	stdTimestampFmt = time.RFC3339
+	StdTimestampFmt = time.RFC3339
 )
 
 var (
@@ -28,14 +28,14 @@ func (ts *Timestamp) Scan(value interface{}) error {
 		ts.Time = &v
 		return nil
 	case string:
-		t, err := time.Parse(stdTimestampFmt, v)
+		t, err := time.Parse(StdTimestampFmt, v)
 		if err != nil {
 			return err
 		}
 		ts.Time = &t
 		return nil
 	case []byte:
-		t, err := time.Parse(stdTimestampFmt, string(v))
+		t, err := time.Parse(StdTimestampFmt, string(v))
 		if err != nil {
 			return err
 		}
@@ -48,15 +48,16 @@ func (ts *Timestamp) Scan(value interface{}) error {
 
 // Value is the Valuer interface implementation
 func (ts *Timestamp) Value() (driver.Value, error) {
-	str := ts.Time.Format(stdTimestampFmt)
+	str := ts.Time.Format(StdTimestampFmt)
 	return str, nil
 }
 
 // String is the fmt.Stringer interface implementation
 func (ts *Timestamp) String() string {
-	return ts.Time.Format(stdTimestampFmt)
+	return ts.Time.Format(StdTimestampFmt)
 }
 
-func now() string {
-	return time.Now().Format(stdTimestampFmt)
+func now() *Timestamp {
+	t := time.Now()
+	return &Timestamp{Time: &t}
 }

--- a/data/timestamp_test.go
+++ b/data/timestamp_test.go
@@ -24,8 +24,8 @@ func TestTimestampScan(t *testing.T) {
 	now := time.Now()
 	testCases := []timestampScanTestCase{
 		timestampScanTestCase{val: now, expectedTime: now, expectedErr: false},
-		timestampScanTestCase{val: now.Format(stdTimestampFmt), expectedTime: now, expectedErr: false},
-		timestampScanTestCase{val: []byte(now.Format(stdTimestampFmt)), expectedTime: now, expectedErr: false},
+		timestampScanTestCase{val: now.Format(StdTimestampFmt), expectedTime: now, expectedErr: false},
+		timestampScanTestCase{val: []byte(now.Format(StdTimestampFmt)), expectedTime: now, expectedErr: false},
 		timestampScanTestCase{val: now.Format(time.ANSIC), expectedTime: now, expectedErr: true},
 		timestampScanTestCase{val: now.Format(time.UnixDate), expectedTime: now, expectedErr: true},
 		timestampScanTestCase{val: now.Format(time.RubyDate), expectedTime: now, expectedErr: true},
@@ -67,8 +67,9 @@ func TestTimestampScan(t *testing.T) {
 
 func TestTimestampNow(t *testing.T) {
 	n := now()
-	if _, err := time.Parse(stdTimestampFmt, n); err != nil {
-		t.Fatal(err)
+	nowTime := time.Now()
+	if n.Time.After(nowTime) {
+		t.Fatalf("Returned time %s was after the current time %s", n.Time, nowTime)
 	}
 }
 
@@ -76,7 +77,7 @@ func TestTimestampString(t *testing.T) {
 	now := time.Now()
 	ts := new(Timestamp)
 	ts.Time = &now
-	if _, err := time.Parse(stdTimestampFmt, ts.String()); err != nil {
+	if _, err := time.Parse(StdTimestampFmt, ts.String()); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -93,7 +94,7 @@ func TestTimestampValue(t *testing.T) {
 	if !ok {
 		t.Fatalf("returned value was not a string")
 	}
-	if _, err := time.Parse(stdTimestampFmt, str); err != nil {
-		t.Fatalf("returned value was not in expected format %s (%s)", stdTimestampFmt, err)
+	if _, err := time.Parse(StdTimestampFmt, str); err != nil {
+		t.Fatalf("returned value was not in expected format %s (%s)", StdTimestampFmt, err)
 	}
 }

--- a/doc/api-architecture.md
+++ b/doc/api-architecture.md
@@ -335,6 +335,45 @@ Moreover, we will assume a more proximate relationship between the API and persi
   ```
   10231
   ```
+- Filter clusters by age
+  - Request type and URL
+    - `GET /:apiVersion/clusters/age?checked_in_before=:timestamp&checked_in_after=:timestamp&created_before=:timestamp&created_after=:timestamp`
+  - 200 Response Body
+
+  ```
+  {
+    "data": [
+      {
+        "id": "8c6da034-c8b1-489a-a55d-a2215d93f934",
+        "firstSeen": "2016-03-11T23:54:39Z",
+        "lastSeen": "2016-03-31T23:54:39Z",
+        "components": [
+          {
+            "component": {
+              "name": "deis-builder",
+              "description": "Deis Builder"
+            },
+            "version": {
+              "train": "stable",
+              "version": "2.0.0",
+              "released": "2016-03-31T23:54:39Z"
+            }
+          },
+          ...
+        ]
+      }
+    ]
+  }
+  ```
+  - Error conditions
+	  - `400 Bad Request` if `created_before` > `checked_in_before`
+		  - Because you can't have clusters that were checked in before they were created
+	  - `400 Bad Request` if `checked_in_after` >= `checked_in_before`
+		  - Because you can't have clusters that were checked in before time T-1 and at the same time checked in after time T+1 (or both at time T)
+	  - `400 Bad Request` if `created_after` >= `created_before`
+		  - Because you can't have clusters that were created after time T+1 and at the same time created before time T-1 (or both at time T)
+	  - `400 Bad Request` if `checked_in_before` <= `created_after`
+		  - Because you can't have clusters that were checked in before time T-1 and at the same time created after time T+1 (or both at time T)
 - Get component metadata for a specific deis cluster
   - Request type and URL
     - `GET /:apiVersion/clusters/:id`

--- a/filter_by_age_test.go
+++ b/filter_by_age_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/arschles/assert"
+	"github.com/deis/workflow-manager-api/data"
+	"github.com/deis/workflow-manager-api/rest"
+	"github.com/deis/workflow-manager/types"
+	"github.com/pborman/uuid"
+)
+
+var (
+	nowTime    = time.Now()
+	futureTime = nowTime.Add(1 * time.Hour)
+	pastTime   = nowTime.Add(-1 * time.Hour)
+)
+
+func timeFuture() time.Time {
+	return futureTime
+}
+
+func timePast() time.Time {
+	return pastTime
+}
+
+func timeNow() time.Time {
+	return nowTime
+}
+
+func TestFilterByClusterAge(t *testing.T) {
+	filter := data.ClusterAgeFilter{
+		CheckedInBefore: timeFuture().Add(2 * time.Hour),
+		CheckedInAfter:  timePast(),
+		CreatedAfter:    timePast().Add(-1 * time.Hour),
+		CreatedBefore:   timeFuture(),
+	}
+	memDB, err := data.NewMemDB()
+	assert.NoErr(t, err)
+	db, err := data.VerifyPersistentStorage(memDB)
+	assert.NoErr(t, err)
+	c := data.ClusterFromDB{}
+	cluster := types.Cluster{ID: uuid.New()}
+	srv := newServer(memDB, data.VersionFromDB{}, data.ClusterCount{}, c)
+	defer srv.Close()
+	_, setErr := c.Set(db, cluster.ID, cluster)
+	assert.NoErr(t, setErr)
+	_, checkInErr := c.Checkin(db, cluster.ID, cluster)
+	assert.NoErr(t, checkInErr)
+	queryPairsMap := map[string]string{
+		rest.CheckedInBeforeQueryStringKey: filter.CheckedInBefore.Format(data.StdTimestampFmt),
+		rest.CheckedInAfterQueryStringKey:  filter.CheckedInAfter.Format(data.StdTimestampFmt),
+		rest.CreatedBeforeQueryStringKey:   filter.CreatedBefore.Format(data.StdTimestampFmt),
+		rest.CreatedAfterQueryStringKey:    filter.CreatedAfter.Format(data.StdTimestampFmt),
+	}
+	queryPairs := make([]string, len(queryPairsMap))
+	i := 0
+	for k, v := range queryPairsMap {
+		queryPairs[i] = fmt.Sprintf("%s=%s", k, v)
+		i++
+	}
+
+	route := urlPath(2, "clusters", "age")
+	route += fmt.Sprintf("?%s", strings.Join(queryPairs, "&"))
+	resp, err := httpGet(srv, route)
+	assert.NoErr(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, resp.StatusCode, http.StatusOK, "response code")
+	var respEnvelope struct {
+		Data []types.Cluster `json:"data"`
+	}
+	assert.NoErr(t, json.NewDecoder(resp.Body).Decode(&respEnvelope))
+	assert.Equal(t, len(respEnvelope.Data), 1, "length of the clusters list")
+	assert.Equal(t, respEnvelope.Data[0].ID, cluster.ID, "returned cluster ID")
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 0a4b244a0a57f044a285064a483060b83cdead61511aa19e2a3fffaddd2921bd
-updated: 2016-04-22T15:47:45.22189698-07:00
+hash: 515330aa934d0c01c8a1cddd2c1233963c21fe200419b015dee18aa0f557a0ee
+updated: 2016-04-27T16:30:57.793010673-07:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c

--- a/glide.yaml
+++ b/glide.yaml
@@ -15,4 +15,7 @@ import:
   - types
 - package: github.com/lib/pq
 - package: github.com/arschles/assert
-- package: github.com/mxk/go-sqlite/sqlite3
+- package: github.com/mxk/go-sqlite
+  subpackages:
+  - sqlite3
+- package: github.com/pborman/uuid

--- a/handlers/cluster_age_util.go
+++ b/handlers/cluster_age_util.go
@@ -1,0 +1,55 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/deis/workflow-manager-api/data"
+	"github.com/deis/workflow-manager-api/rest"
+)
+
+type errInvalidTimeFmt struct {
+	key string
+	err error
+}
+
+func (e errInvalidTimeFmt) Error() string {
+	return fmt.Sprintf("%s is an invalid timestamp (%s)", e.key, e.err)
+}
+
+func parseAgeQueryKeys(r *http.Request) (*data.ClusterAgeFilter, error) {
+	checkedInBefore, err := time.Parse(
+		data.StdTimestampFmt,
+		r.URL.Query().Get(rest.CheckedInBeforeQueryStringKey),
+	)
+	if err != nil {
+		return nil, errInvalidTimeFmt{key: rest.CheckedInBeforeQueryStringKey, err: err}
+	}
+
+	checkedInAfter, err := time.Parse(
+		data.StdTimestampFmt,
+		r.URL.Query().Get(rest.CheckedInAfterQueryStringKey),
+	)
+	if err != nil {
+		return nil, errInvalidTimeFmt{key: rest.CheckedInAfterQueryStringKey, err: err}
+	}
+
+	createdBefore, err := time.Parse(
+		data.StdTimestampFmt,
+		r.URL.Query().Get(rest.CreatedBeforeQueryStringKey),
+	)
+	if err != nil {
+		return nil, errInvalidTimeFmt{key: rest.CreatedBeforeQueryStringKey, err: err}
+	}
+
+	createdAfter, err := time.Parse(
+		data.StdTimestampFmt,
+		r.URL.Query().Get(rest.CreatedAfterQueryStringKey),
+	)
+	if err != nil {
+		return nil, errInvalidTimeFmt{key: rest.CreatedAfterQueryStringKey, err: err}
+	}
+
+	return data.NewClusterAgeFilter(checkedInBefore, checkedInAfter, createdBefore, createdAfter)
+}

--- a/handlers/clusters_age_handler.go
+++ b/handlers/clusters_age_handler.go
@@ -1,0 +1,40 @@
+package handlers
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/deis/workflow-manager-api/data"
+	"github.com/deis/workflow-manager/types"
+)
+
+// ClustersAge is the handler for the GET /{apiVersion}/clusters/age endpoint
+func ClustersAge(db *sql.DB, cluster data.Cluster) http.Handler {
+	type clustersAgeResp struct {
+		Data []types.Cluster `json:"data"`
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		clusterAgeFilter, err := parseAgeQueryKeys(r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		clusters, err := cluster.FilterByAge(db, clusterAgeFilter)
+		if err != nil {
+			log.Printf("Error filtering clusters by age (%s)", err)
+			http.Error(w, "database error", http.StatusInternalServerError)
+			return
+		}
+		ret := clustersAgeResp{Data: clusters}
+		if err := json.NewEncoder(w).Encode(ret); err != nil {
+			log.Printf("Error json-encoding clusters (%s)", err)
+			http.Error(w, fmt.Sprintf("error encoding clusters (%s)", err), http.StatusInternalServerError)
+			return
+		}
+
+	})
+}

--- a/rest/cluster_age.go
+++ b/rest/cluster_age.go
@@ -1,0 +1,16 @@
+package rest
+
+const (
+	// CheckedInBeforeQueryStringKey is the query string key to filter clusters checked in before a
+	// specified time
+	CheckedInBeforeQueryStringKey = "checked_in_before"
+	// CheckedInAfterQueryStringKey is the query string key to filter clusters checked in after a
+	// specified time
+	CheckedInAfterQueryStringKey = "checked_in_after"
+	// CreatedBeforeQueryStringKey is the query string key to filter clusters created before a
+	// specified time
+	CreatedBeforeQueryStringKey = "created_before"
+	// CreatedAfterQueryStringKey is the query string key to filter clusters created after a
+	// specified time
+	CreatedAfterQueryStringKey = "created_after"
+)

--- a/server.go
+++ b/server.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/deis/workflow-manager-api/data"
 	"github.com/deis/workflow-manager-api/handlers"
+	"github.com/deis/workflow-manager-api/rest"
 	"github.com/gorilla/mux"
 	_ "github.com/lib/pq"
 )
@@ -45,6 +46,17 @@ func getRoutes(db *sql.DB, version data.Version, count data.Count, cluster data.
 	r.Handle("/{apiVersion}/versions/{train}/{component}/{version}", handlers.PublishVersion(db, version)).Methods("POST").
 		Headers(handlers.ContentTypeHeaderKey, handlers.JSONContentType)
 	r.Handle("/{apiVersion}/clusters/count", handlers.ClustersCount(db, count)).Methods("GET")
+	r.Handle("/{apiVersion}/clusters/age", handlers.ClustersAge(db, cluster)).Methods("GET").
+		Queries(
+			rest.CheckedInBeforeQueryStringKey,
+			"",
+			rest.CheckedInAfterQueryStringKey,
+			"",
+			rest.CreatedBeforeQueryStringKey,
+			"",
+			rest.CreatedAfterQueryStringKey,
+			"",
+		)
 	r.Handle("/{apiVersion}/clusters/{id}", handlers.GetCluster(db, cluster)).Methods("GET")
 	r.Handle("/{apiVersion}/clusters/{id}", handlers.ClusterCheckin(db, cluster)).Methods("POST").
 		Headers(handlers.ContentTypeHeaderKey, handlers.JSONContentType)


### PR DESCRIPTION
Partially addresses #60, #58 and #57 
Fixes #44 

Still TODO:
- [x] Implement `(*github.com/deis/workflow-manager-api/data/ClusterFromDB).FilterByAge`
- [x] Add unit test for the previous
- [x] Add unit test for the `GET /:apiVersion/clusters/age?...` endpoint
- [x] Document error cases in the filters in `api-architecture.md`
