### PR TITLE
fix(data): updateClusterDBRecord now has valid SQL

### DIFF
--- a/data/data.go
+++ b/data/data.go
@@ -665,7 +665,7 @@ func updateVersionDBRecord(db *sql.DB, componentVersion types.ComponentVersion) 
 }
 
 func updateClusterDBRecord(db *sql.DB, id string, data []byte) (sql.Result, error) {
-	update := fmt.Sprintf("UPDATE %s SET data='%s', WHERE cluster_id='%s'", clustersTableName, string(data), id)
+	update := fmt.Sprintf("UPDATE %s SET data='%s' WHERE cluster_id='%s'", clustersTableName, string(data), id)
 	return db.Exec(update)
 }
 


### PR DESCRIPTION
This fixes a regression in recent change due to the cluster table structure. Additionally, test coverage now includes this function: by calling ClusterFromDB{}.Set() twice in succession with cluster objects that have the same `ID` property inside TestClusterFromDBRoundTrip we ensure that we're invoking data.updateClusterDBRecord().

fixes #66
