### PR TITLE
using updated workflow-manager types.Version.Data map[string]interface{}

### DIFF
--- a/data/common_test.go
+++ b/data/common_test.go
@@ -11,5 +11,7 @@ const (
 )
 
 var (
-	versionData = []byte(`{}`)
+	versionData = map[string]interface{}{
+		"notes": "release notes",
+	}
 )

--- a/data/data.go
+++ b/data/data.go
@@ -201,16 +201,9 @@ func (c VersionFromDB) Get(db *sql.DB, cV types.ComponentVersion) (types.Compone
 	if err := row.Scan(&s, &rowResult.componentName, &rowResult.train, &rowResult.version, &rowResult.releaseTimestamp, &rowResult.data); err != nil {
 		return types.ComponentVersion{}, err
 	}
-	componentVersion := types.ComponentVersion{
-		Component: types.Component{
-			Name: rowResult.componentName,
-		},
-		Version: types.Version{
-			Version:  rowResult.version,
-			Released: rowResult.releaseTimestamp.String(),
-			Train:    rowResult.train,
-			Data:     rowResult.data,
-		},
+	componentVersion, err := parseDBVersion(rowResult)
+	if err != nil {
+		return types.ComponentVersion{}, err
 	}
 	return componentVersion, nil
 }
@@ -628,6 +621,11 @@ func newClusterDBRecord(db *sql.DB, id string, data []byte) (sql.Result, error) 
 }
 
 func newVersionDBRecord(db *sql.DB, componentVersion types.ComponentVersion) (sql.Result, error) {
+	data, err := json.Marshal(componentVersion.Version.Data)
+	if err != nil {
+		log.Printf("JSON marshaling failed (%s)", err)
+		return nil, err
+	}
 	insert := fmt.Sprintf(
 		"INSERT INTO %s (%s, %s, %s, %s, %s) VALUES('%s', '%s', '%s', '%s', '%s')",
 		versionsTableName,
@@ -640,7 +638,7 @@ func newVersionDBRecord(db *sql.DB, componentVersion types.ComponentVersion) (sq
 		componentVersion.Version.Train,
 		componentVersion.Version.Version,
 		componentVersion.Version.Released,
-		string(componentVersion.Version.Data[:]),
+		string(data),
 	)
 	return db.Exec(insert)
 }
@@ -648,6 +646,7 @@ func newVersionDBRecord(db *sql.DB, componentVersion types.ComponentVersion) (sq
 func updateVersionDBRecord(db *sql.DB, componentVersion types.ComponentVersion) (sql.Result, error) {
 	data, err := json.Marshal(componentVersion.Version.Data)
 	if err != nil {
+		log.Printf("JSON marshaling failed (%s)", err)
 		return nil, err
 	}
 	update := fmt.Sprintf(

--- a/data/util.go
+++ b/data/util.go
@@ -28,8 +28,8 @@ func parseDBVersions(versions []VersionsTable) ([]types.ComponentVersion, error)
 }
 
 func parseDBVersion(version VersionsTable) (types.ComponentVersion, error) {
-	versionData, err := version.data.MarshalJSON()
-	if err != nil {
+	data := make(map[string]interface{})
+	if err := json.Unmarshal(version.data, &data); err != nil {
 		return types.ComponentVersion{}, err
 	}
 	return types.ComponentVersion{
@@ -40,7 +40,7 @@ func parseDBVersion(version VersionsTable) (types.ComponentVersion, error) {
 			Train:    version.train,
 			Version:  version.version,
 			Released: version.releaseTimestamp.String(),
-			Data:     versionData,
+			Data:     data,
 		},
 	}, nil
 }

--- a/data/util_test.go
+++ b/data/util_test.go
@@ -20,7 +20,7 @@ func TestParseJSONComponentFail(t *testing.T) {
 func TestParseJSONComponentSucc(t *testing.T) {
 	cVer := types.ComponentVersion{
 		Component:       types.Component{Name: "test name", Description: "test description"},
-		Version:         types.Version{Train: "stable", Version: "test version", Released: "test release", Data: []byte(`{}`)},
+		Version:         types.Version{Train: "stable", Version: "test version", Released: "test release", Data: versionData},
 		UpdateAvailable: "test update avail",
 	}
 	b, err := json.Marshal(cVer)

--- a/data/version_from_db_test.go
+++ b/data/version_from_db_test.go
@@ -72,7 +72,9 @@ func TestVersionFromDBLatest(t *testing.T) {
 		cv.Version.Train = train
 		cv.Version.Version = fmt.Sprintf("testversion%d", i)
 		cv.Version.Released = time.Now().Add(time.Duration(i) * time.Hour).Format(released)
-		cv.Version.Data = []byte(fmt.Sprintf("data%d", i))
+		cv.Version.Data = map[string]interface{}{
+			"notes": fmt.Sprintf("data%d", i),
+		}
 		if i == latestCVIdx {
 			cv.Version.Released = time.Now().Add(time.Duration(numCVs+1) * time.Hour).Format(released)
 		}
@@ -91,7 +93,7 @@ func TestVersionFromDBLatest(t *testing.T) {
 	assert.Equal(t, cv.Version.Train, exCV.Version.Train, "component version")
 	assert.Equal(t, cv.Version.Version, exCV.Version.Version, "component version")
 	assert.Equal(t, cv.Version.Released, exCV.Version.Released, "component release time")
-	assert.Equal(t, string(cv.Version.Data), string(exCV.Version.Data), "component version data")
+	assert.Equal(t, cv.Version.Data, exCV.Version.Data, "component version data")
 }
 
 func TestVersionFromDBMultiLatest(t *testing.T) {

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,12 @@
 hash: 0a4b244a0a57f044a285064a483060b83cdead61511aa19e2a3fffaddd2921bd
-updated: 2016-04-19T10:38:19.04822411-07:00
+updated: 2016-04-22T15:47:45.22189698-07:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c
 - name: github.com/arschles/assert
   version: d21ecd4884be33397d1298c3738b2b4937c7f499
 - name: github.com/aws/aws-sdk-go
-  version: eb85a963838ae4ef2773c5b07f9e5bbf3865da46
+  version: 4acef85041b5e039cc17094885dd3ce93a7be290
   subpackages:
   - aws
   - aws/session
@@ -40,7 +40,7 @@ imports:
   subpackages:
   - spew
 - name: github.com/deis/workflow-manager
-  version: 6a7acfe9d13bb7c289d24e3f01b0029c10df0cec
+  version: a21b95fc764d444a19a375bb1fe99a5c98a67432
   subpackages:
   - components
   - types
@@ -102,7 +102,7 @@ imports:
 - name: github.com/google/gofuzz
   version: bbcb9da2d746f8bdbd6a936686a0a6067ada0ec5
 - name: github.com/gorilla/context
-  version: 1ea25387ff6f684839d82767c1733ff4d4d15d0a
+  version: a8d44e7d8e4d532b6a27a02dd82abb31cc1b01bd
 - name: github.com/gorilla/mux
   version: 0eeaf8392f5b04950925b8a69fe70f110fa7cbfc
 - name: github.com/jmespath/go-jmespath

--- a/server_test.go
+++ b/server_test.go
@@ -43,7 +43,9 @@ func TestGetVersion(t *testing.T) {
 	defer srv.Close()
 	componentVer := types.ComponentVersion{
 		Component: types.Component{Name: componentName},
-		Version:   types.Version{Train: "beta", Version: "2.0.0-beta-2", Released: "2016-03-31T23:54:39Z", Data: []byte(`{"description": "release details"}`)},
+		Version: types.Version{Train: "beta", Version: "2.0.0-beta-2", Released: "2016-03-31T23:54:39Z", Data: map[string]interface{}{
+			"notes": "release notes",
+		}},
 	}
 	_, err = data.SetVersion(componentVer, db, versionFromDB)
 	assert.NoErr(t, err)
@@ -68,11 +70,15 @@ func TestGetComponentTrainVersions(t *testing.T) {
 	componentVers := []types.ComponentVersion{}
 	componentVer1 := types.ComponentVersion{
 		Component: types.Component{Name: componentName},
-		Version:   types.Version{Train: "beta", Version: "2.0.0-beta-1", Released: "2016-03-30T23:54:39Z", Data: []byte(`{"description": "release details"}`)},
+		Version: types.Version{Train: "beta", Version: "2.0.0-beta-1", Released: "2016-03-30T23:54:39Z", Data: map[string]interface{}{
+			"notes": "release notes",
+		}},
 	}
 	componentVer2 := types.ComponentVersion{
 		Component: types.Component{Name: componentName},
-		Version:   types.Version{Train: "beta", Version: "2.0.0-beta-2", Released: "2016-03-31T23:54:39Z", Data: []byte(`{"description": "release details"}`)},
+		Version: types.Version{Train: "beta", Version: "2.0.0-beta-2", Released: "2016-03-31T23:54:39Z", Data: map[string]interface{}{
+			"notes": "release notes",
+		}},
 	}
 	componentVers = append(componentVers, componentVer1)
 	componentVers = append(componentVers, componentVer2)
@@ -113,7 +119,9 @@ func TestGetLatestComponentTrainVersion(t *testing.T) {
 		cv.Version.Train = train
 		cv.Version.Version = fmt.Sprintf("testversion%d", i)
 		cv.Version.Released = time.Now().Add(time.Duration(i) * time.Hour).Format(releaseTimeFormat)
-		cv.Version.Data = []byte(fmt.Sprintf("data%d", i))
+		cv.Version.Data = map[string]interface{}{
+			"notes": fmt.Sprintf("data%d", i),
+		}
 		if i == latestCVIdx {
 			cv.Version.Released = time.Now().Add(time.Duration(numCVs+1) * time.Hour).Format(releaseTimeFormat)
 		}
@@ -138,7 +146,7 @@ func TestGetLatestComponentTrainVersion(t *testing.T) {
 	assert.Equal(t, cv.Version.Train, exCV.Version.Train, "component version")
 	assert.Equal(t, cv.Version.Version, exCV.Version.Version, "component version")
 	assert.Equal(t, cv.Version.Released, exCV.Version.Released, "component release time")
-	assert.Equal(t, string(cv.Version.Data), string(exCV.Version.Data), "component version data")
+	assert.Equal(t, cv.Version.Data, exCV.Version.Data, "component version data")
 }
 
 // tests the POST /{apiVersion}/versions/{train}/{component}/{version} endpoint
@@ -154,7 +162,9 @@ func TestPostVersions(t *testing.T) {
 	version := "2.0.0-beta-2"
 	componentVer := types.ComponentVersion{
 		Component: types.Component{Name: componentName},
-		Version:   types.Version{Train: train, Version: version, Released: "2016-03-31T23:54:39Z", Data: []byte(`{"description": "release details"}`)},
+		Version: types.Version{Train: train, Version: version, Released: "2016-03-31T23:54:39Z", Data: map[string]interface{}{
+			"notes": "release notes",
+		}},
 	}
 	body := new(bytes.Buffer)
 	assert.NoErr(t, json.NewEncoder(body).Encode(componentVer))


### PR DESCRIPTION
to consume this change in workflow-manager:

https://github.com/deis/workflow-manager/commit/184c4fb088da081688a062556b3b8f16d81113bd

The benefit is that able to more gracefully represent `Version` types in-code. Required changes to all the conversion mechanisms that get `Version` data into the db, and back from the db.

Includes an updated glide.lock.
