### PR TITLE
chore(Makefile): adding build dep to docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ build:
 test:
 	${DEV_ENV_CMD} sh -c 'go test -tags testonly $$(glide nv)'
 
-docker-build:
+docker-build: build
 	docker build --rm -t ${IMAGE} rootfs
 	docker tag ${IMAGE} ${MUTABLE_IMAGE}
 


### PR DESCRIPTION
We can't really do a "docker-build" without first doing a build, so adding it as a dependency.
