### PR TITLE
fix(.travis.yml): set the global image prefix to deisci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ branches:
 cache:
   directories:
     - vendor
+env:
+  global:
+    - IMAGE_PREFIX=deisci
 services:
   - docker
 sudo: required


### PR DESCRIPTION
this change allows all CI builds to run docker-build, but CI builds on master can deploy by simply running `docker push`

cc/ @jackfrancis 
