### PR TITLE
ref(data,handlers,server_test.go): remove the Version interface's Get function

### DIFF
--- a/data/version_from_db.go
+++ b/data/version_from_db.go
@@ -12,24 +12,6 @@ import (
 // VersionFromDB fulfills the Version interface
 type VersionFromDB struct{}
 
-// Get method for VersionFromDB, the actual database/sql.DB implementation
-func (c VersionFromDB) Get(db *sql.DB, cV types.ComponentVersion) (types.ComponentVersion, error) {
-	row := getDBRecord(db, versionsTableName,
-		[]string{versionsTableComponentNameKey, versionsTableTrainKey, versionsTableVersionKey},
-		[]string{cV.Component.Name, cV.Version.Train, cV.Version.Version})
-	rowResult := VersionsTable{}
-	//TODO: sql.NullString is to pass tests, not for production
-	var s sql.NullString
-	if err := row.Scan(&s, &rowResult.componentName, &rowResult.train, &rowResult.version, &rowResult.releaseTimestamp, &rowResult.data); err != nil {
-		return types.ComponentVersion{}, err
-	}
-	componentVersion, err := parseDBVersion(rowResult)
-	if err != nil {
-		return types.ComponentVersion{}, err
-	}
-	return componentVersion, nil
-}
-
 // Collection method for VersionFromDB, the actual database/sql.DB implementation
 func (c VersionFromDB) Collection(db *sql.DB, train string, component string) ([]types.ComponentVersion, error) {
 	rows, err := getDBRecords(db, versionsTableName,
@@ -116,7 +98,7 @@ func (c VersionFromDB) Set(db *sql.DB, componentVersion types.ComponentVersion) 
 	if affected == 0 {
 		log.Println("no records updated")
 	} else if affected == 1 {
-		ret, err = c.Get(db, componentVersion)
+		ret, err = GetVersion(db, componentVersion)
 		if err != nil {
 			return types.ComponentVersion{}, err
 		}

--- a/data/version_from_db_test.go
+++ b/data/version_from_db_test.go
@@ -35,7 +35,7 @@ func TestVersionFromDBRoundTrip(t *testing.T) {
 	assert.NoErr(t, err)
 	ver := VersionFromDB{}
 	componentVersion := testComponentVersion()
-	cVerNoExist, err := ver.Get(sqliteDB, componentVersion)
+	cVerNoExist, err := GetVersion(sqliteDB, componentVersion)
 	assert.True(t, err != nil, "error not returned but expected")
 	assert.Equal(t, cVerNoExist, types.ComponentVersion{}, "component version")
 	cVerSet, err := ver.Set(sqliteDB, componentVersion)
@@ -44,7 +44,7 @@ func TestVersionFromDBRoundTrip(t *testing.T) {
 	assert.Equal(t, cVerSet.Version.Version, componentVersion.Version.Version, "version string")
 	assert.Equal(t, cVerSet.Version.Released, componentVersion.Version.Released, "released string")
 	assert.Equal(t, cVerSet.Version.Train, componentVersion.Version.Train, "version train")
-	getCVer, err := ver.Get(sqliteDB, componentVersion)
+	getCVer, err := GetVersion(sqliteDB, componentVersion)
 	assert.NoErr(t, err)
 	assert.Equal(t, getCVer.Component.Name, componentVersion.Component.Name, "component name")
 	assert.Equal(t, getCVer.Version.Version, componentVersion.Version.Version, "version string")

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -85,7 +85,7 @@ func GetVersion(db *sql.DB, v data.Version) http.Handler {
 			Component: types.Component{Name: component},
 			Version:   types.Version{Train: train, Version: version},
 		}
-		componentVersion, err := data.GetVersion(params, db, v)
+		componentVersion, err := data.GetVersion(db, params)
 		if err != nil {
 			log.Printf("data.GetVersion error (%s)", err)
 			http.NotFound(w, r)

--- a/server_test.go
+++ b/server_test.go
@@ -176,7 +176,7 @@ func TestPostVersions(t *testing.T) {
 	assert.NoErr(t, json.NewDecoder(resp.Body).Decode(retComponentVersion))
 	// TODO: version data property not traveling and returning as expected
 	assert.Equal(t, *retComponentVersion, componentVer, "component version")
-	fetchedComponentVersion, err := data.GetVersion(componentVer, db, versionFromDB)
+	fetchedComponentVersion, err := data.GetVersion(db, componentVer)
 	assert.NoErr(t, err)
 	assert.Equal(t, fetchedComponentVersion, componentVer, "component version")
 }


### PR DESCRIPTION
prefer to use a top-level function in the data package instead

Makes progress toward #61 
