### PR TITLE
ref(data): remove the Version interface's Set function

### DIFF
--- a/data/version_from_db_test.go
+++ b/data/version_from_db_test.go
@@ -33,12 +33,11 @@ func TestVersionFromDBRoundTrip(t *testing.T) {
 	db, err := VerifyPersistentStorage(memDB)
 	assert.NotNil(t, db, "db")
 	assert.NoErr(t, err)
-	ver := VersionFromDB{}
 	componentVersion := testComponentVersion()
 	cVerNoExist, err := GetVersion(sqliteDB, componentVersion)
 	assert.True(t, err != nil, "error not returned but expected")
 	assert.Equal(t, cVerNoExist, types.ComponentVersion{}, "component version")
-	cVerSet, err := ver.Set(sqliteDB, componentVersion)
+	cVerSet, err := SetVersion(sqliteDB, componentVersion)
 	assert.NoErr(t, err)
 	assert.Equal(t, cVerSet.Component.Name, componentVersion.Component.Name, "component name")
 	assert.Equal(t, cVerSet.Version.Version, componentVersion.Version.Version, "version string")
@@ -78,7 +77,7 @@ func TestVersionFromDBLatest(t *testing.T) {
 		if i == latestCVIdx {
 			cv.Version.Released = time.Now().Add(time.Duration(numCVs+1) * time.Hour).Format(released)
 		}
-		if _, setErr := ver.Set(sqliteDB, cv); setErr != nil {
+		if _, setErr := SetVersion(sqliteDB, cv); setErr != nil {
 			t.Fatalf("error setting component version %d (%s)", i, setErr)
 		}
 		componentVersions[i] = cv
@@ -136,7 +135,7 @@ func TestVersionFromDBMultiLatest(t *testing.T) {
 				if releaseTimes[ct.String()].Before(cvReleaseTime) {
 					releaseTimes[ct.String()] = cvReleaseTime
 				}
-				if _, setErr := ver.Set(db, cv); setErr != nil {
+				if _, setErr := SetVersion(db, cv); setErr != nil {
 					t.Fatalf("error setting component version %d (%s)", idx, setErr)
 				}
 			}

--- a/get_latest_versions_test.go
+++ b/get_latest_versions_test.go
@@ -46,10 +46,10 @@ func TestGetLatestVersions(t *testing.T) {
 			},
 		}
 
-		if _, err := versionFromDB.Set(db, cv1); err != nil {
+		if _, err := data.SetVersion(db, cv1); err != nil {
 			t.Fatalf("Error setting component %d (%s)", i, err)
 		}
-		if _, err := versionFromDB.Set(db, cv2); err != nil {
+		if _, err := data.SetVersion(db, cv2); err != nil {
 			t.Fatalf("Error setting component %d (%s)", i, err)
 		}
 		components[cv2.Component.Name] = cv2

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -138,7 +138,7 @@ func PublishVersion(db *sql.DB, v data.Version) http.Handler {
 		componentVersion.Component.Name = routeParams["component"]
 		componentVersion.Version.Train = routeParams["train"]
 		componentVersion.Version.Version = routeParams["version"]
-		result, err := data.SetVersion(componentVersion, db, v)
+		result, err := data.SetVersion(db, componentVersion)
 		if err != nil {
 			log.Printf("data.SetVersion error (%s)", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/server_test.go
+++ b/server_test.go
@@ -47,7 +47,7 @@ func TestGetVersion(t *testing.T) {
 			"notes": "release notes",
 		}},
 	}
-	_, err = data.SetVersion(componentVer, db, versionFromDB)
+	_, err = data.SetVersion(db, componentVer)
 	assert.NoErr(t, err)
 	resp, err := httpGet(srv, urlPath(1, "versions", componentVer.Version.Train, componentVer.Component.Name, componentVer.Version.Version))
 	assert.NoErr(t, err)
@@ -82,9 +82,9 @@ func TestGetComponentTrainVersions(t *testing.T) {
 	}
 	componentVers = append(componentVers, componentVer1)
 	componentVers = append(componentVers, componentVer2)
-	_, err = data.SetVersion(componentVers[0], db, versionFromDB)
+	_, err = data.SetVersion(db, componentVers[0])
 	assert.NoErr(t, err)
-	_, err = data.SetVersion(componentVers[1], db, versionFromDB)
+	_, err = data.SetVersion(db, componentVers[1])
 	assert.NoErr(t, err)
 	resp, err := httpGet(srv, urlPath(1, "versions", componentVer1.Version.Train, componentVer1.Component.Name))
 	assert.NoErr(t, err)
@@ -125,7 +125,7 @@ func TestGetLatestComponentTrainVersion(t *testing.T) {
 		if i == latestCVIdx {
 			cv.Version.Released = time.Now().Add(time.Duration(numCVs+1) * time.Hour).Format(releaseTimeFormat)
 		}
-		if _, setErr := ver.Set(db, cv); setErr != nil {
+		if _, setErr := data.SetVersion(db, cv); setErr != nil {
 			t.Fatalf("error setting component version %d (%s)", i, setErr)
 		}
 		componentVersions[i] = cv


### PR DESCRIPTION
in favor of a single package exported func

Makes progress toward #61 
