### PR TITLE
ref(data,handlers): remove the Version interfaces's Latest func

### DIFF
--- a/data/version_from_db_test.go
+++ b/data/version_from_db_test.go
@@ -59,7 +59,6 @@ func TestVersionFromDBLatest(t *testing.T) {
 	db, err := VerifyPersistentStorage(memDB)
 	assert.NotNil(t, db, "db")
 	assert.NoErr(t, err)
-	ver := VersionFromDB{}
 
 	const numCVs = 4
 	const latestCVIdx = 2
@@ -82,7 +81,7 @@ func TestVersionFromDBLatest(t *testing.T) {
 		}
 		componentVersions[i] = cv
 	}
-	cv, err := ver.Latest(sqliteDB, train, componentName)
+	cv, err := GetLatestVersion(sqliteDB, train, componentName)
 	assert.NoErr(t, err)
 	exCV := componentVersions[latestCVIdx]
 	assert.Equal(t, cv.Component.Name, exCV.Component.Name, "component name")

--- a/handlers/get_latest_component_train_version.go
+++ b/handlers/get_latest_component_train_version.go
@@ -25,7 +25,7 @@ func GetLatestComponentTrainVersion(db *sql.DB, ver data.Version) http.Handler {
 			http.Error(w, "component is required", http.StatusBadRequest)
 			return
 		}
-		cv, err := ver.Latest(db, train, component)
+		cv, err := data.GetLatestVersion(db, train, component)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("error getting component (%s)", err), http.StatusInternalServerError)
 			return


### PR DESCRIPTION
Prefer a single exported func instead

Contributes to #61 
