### PR TITLE
ref(data,filter_by_age_test.go): remove the Cluster interface's Checkin func

### DIFF
--- a/data/cluster_from_db.go
+++ b/data/cluster_from_db.go
@@ -52,20 +52,6 @@ func (c ClusterFromDB) Set(db *sql.DB, id string, cluster types.Cluster) (types.
 	return ret, nil
 }
 
-// Checkin method for ClusterFromDB, the actual database/sql.DB implementation
-func (c ClusterFromDB) Checkin(db *sql.DB, id string, cluster types.Cluster) (sql.Result, error) {
-	js, err := json.Marshal(cluster)
-	if err != nil {
-		fmt.Println("error marshaling data")
-	}
-	result, err := newClusterCheckinsDBRecord(db, id, now(), js)
-	if err != nil {
-		log.Println("cluster checkin db record not created", err)
-		return nil, err
-	}
-	return result, nil
-}
-
 // FilterByAge returns a slice of clusters whose various time fields match the requirements
 // in the given filter. Note that the filter's requirements are a conjunction, not a disjunction
 func (c ClusterFromDB) FilterByAge(db *sql.DB, filter *ClusterAgeFilter) ([]types.Cluster, error) {

--- a/data/cluster_from_db_test.go
+++ b/data/cluster_from_db_test.go
@@ -68,8 +68,7 @@ func TestClusterFromDBRoundTrip(t *testing.T) {
 func TestClusterFromDBCheckin(t *testing.T) {
 	sqliteDB, err := newDB()
 	assert.NoErr(t, err)
-	c := ClusterFromDB{}
-	res, err := c.Checkin(sqliteDB, clusterID, testCluster())
+	res, err := CheckInCluster(sqliteDB, clusterID, testCluster())
 	assert.NoErr(t, err)
 	rowsAffected, err := res.RowsAffected()
 	assert.NoErr(t, err)

--- a/filter_by_age_test.go
+++ b/filter_by_age_test.go
@@ -50,7 +50,7 @@ func TestFilterByClusterAge(t *testing.T) {
 	defer srv.Close()
 	_, setErr := c.Set(db, cluster.ID, cluster)
 	assert.NoErr(t, setErr)
-	_, checkInErr := c.Checkin(db, cluster.ID, cluster)
+	_, checkInErr := data.CheckInCluster(db, cluster.ID, cluster)
 	assert.NoErr(t, checkInErr)
 	queryPairsMap := map[string]string{
 		rest.CheckedInBeforeQueryStringKey: filter.CheckedInBefore.Format(data.StdTimestampFmt),


### PR DESCRIPTION
Prefer a single exported func instead

Contributes to https://github.com/deis/workflow-manager-api/issues/61
