### PR TITLE
ref(handlers,data): remove the Clusters interface's Filter func

### DIFF
--- a/data/cluster_from_db_filter_by_age_test.go
+++ b/data/cluster_from_db_filter_by_age_test.go
@@ -167,7 +167,7 @@ func TestClusterFromDBFilterByAge(t *testing.T) {
 			}
 
 			// filter the cluster & test results
-			filteredClusters, filterErr := c.FilterByAge(db, &fca.filter)
+			filteredClusters, filterErr := FilterClustersByAge(db, &fca.filter)
 			if filterErr != nil {
 				t.Errorf("error filtering for case %d (%s)", i, filterErr)
 				return
@@ -185,7 +185,7 @@ func TestClusterFromDBFilterByAge(t *testing.T) {
 				t.Errorf("error creating new DB in case %d (%s)", i, err)
 				return
 			}
-			filteredClusters, filterErr = c.FilterByAge(db, &fca.filter)
+			filteredClusters, filterErr = FilterClustersByAge(db, &fca.filter)
 			if filterErr != nil {
 				t.Errorf("error filtering for case %d (%s)", i, filterErr)
 				return

--- a/handlers/clusters_age_handler.go
+++ b/handlers/clusters_age_handler.go
@@ -23,7 +23,7 @@ func ClustersAge(db *sql.DB, cluster data.Cluster) http.Handler {
 			return
 		}
 
-		clusters, err := cluster.FilterByAge(db, clusterAgeFilter)
+		clusters, err := data.FilterClustersByAge(db, clusterAgeFilter)
 		if err != nil {
 			log.Printf("Error filtering clusters by age (%s)", err)
 			http.Error(w, "database error", http.StatusInternalServerError)


### PR DESCRIPTION
Prefer a single exported func instead

Contributes to https://github.com/deis/workflow-manager-api/issues/61
