### PR TITLE
ref(*): move some funcs in data/versions.go over to gorm

### DIFF
--- a/data/cluster_filter_by_age_test.go
+++ b/data/cluster_filter_by_age_test.go
@@ -159,19 +159,19 @@ func TestClusterFromDBFilterByAge(t *testing.T) {
 				t.Errorf("error JSON serializing cluster %d (%s)", i, err)
 				return
 			}
-			if _, setErr := newClusterDBRecord(db, cluster.ID, clusterJSON); setErr != nil {
+			if _, setErr := newClusterDBRecord(db.DB(), cluster.ID, clusterJSON); setErr != nil {
 				t.Errorf("error creating cluster %s in DB (%s)", cluster.ID, setErr)
 				return
 			}
 
 			// check in the cluster
-			if cErr := createCheckin(db, cluster, &Timestamp{Time: &fca.createdAt}); cErr != nil {
+			if cErr := createCheckin(db.DB(), cluster, &Timestamp{Time: &fca.createdAt}); cErr != nil {
 				t.Errorf("error creating checkin for case %d (%s)", i, cErr)
 				return
 			}
 
 			// filter the cluster & test results
-			filteredClusters, filterErr := FilterClustersByAge(db, &fca.filter)
+			filteredClusters, filterErr := FilterClustersByAge(db.DB(), &fca.filter)
 			if filterErr != nil {
 				t.Errorf("error filtering for case %d (%s)", i, filterErr)
 				return
@@ -189,7 +189,7 @@ func TestClusterFromDBFilterByAge(t *testing.T) {
 				t.Errorf("error creating new DB in case %d (%s)", i, err)
 				return
 			}
-			filteredClusters, filterErr = FilterClustersByAge(db, &fca.filter)
+			filteredClusters, filterErr = FilterClustersByAge(db.DB(), &fca.filter)
 			if filterErr != nil {
 				t.Errorf("error filtering for case %d (%s)", i, filterErr)
 				return

--- a/data/data.go
+++ b/data/data.go
@@ -1,12 +1,13 @@
 package data
 
 import (
+	"database/sql"
 	"fmt"
 	"log"
 	"os"
 	"strconv"
 
-	"database/sql"
+	"github.com/jinzhu/gorm"
 )
 
 const (
@@ -21,13 +22,6 @@ const (
 	clustersCheckinsTableClusterIDKey        = "cluster_id"
 	clustersCheckinsTableClusterCreatedAtKey = "created_at"
 	clustersCheckinsTableDataKey             = "data"
-	versionsTableName                        = "versions"
-	versionsTableIDKey                       = "version_id"
-	versionsTableComponentNameKey            = "component_name"
-	versionsTableTrainKey                    = "train"
-	versionsTableVersionKey                  = "version"
-	versionsTableReleaseTimeStampKey         = "release_timestamp"
-	versionsTableDataKey                     = "data"
 )
 
 var (
@@ -45,34 +39,34 @@ func (e errNoMoreRows) Error() string {
 }
 
 // VerifyPersistentStorage is a high level interace for verifying storage abstractions
-func VerifyPersistentStorage(db *sql.DB) error {
-	if err := verifyVersionsTable(db); err != nil {
+func VerifyPersistentStorage(db *gorm.DB) error {
+	if _, err := createOrUpdateVersionsTable(db); err != nil {
 		log.Println("unable to verify " + versionsTableName + " table")
 		return err
 	}
-	count, err := getTableCount(db, versionsTableName)
+	count, err := getTableCount(db.DB(), versionsTableName)
 	if err != nil {
 		log.Println("unable to get record count for " + versionsTableName + " table")
 		return err
 	}
 	log.Println("counted " + strconv.Itoa(count) + " records for " + versionsTableName + " table")
-	err = verifyClustersTable(db)
+	err = verifyClustersTable(db.DB())
 	if err != nil {
 		log.Println("unable to verify " + clustersTableName + " table")
 		return err
 	}
-	count, err = getTableCount(db, clustersTableName)
+	count, err = getTableCount(db.DB(), clustersTableName)
 	if err != nil {
 		log.Println("unable to get record count for " + clustersTableName + " table")
 		return err
 	}
 	log.Println("counted " + strconv.Itoa(count) + " records for " + clustersTableName + " table")
-	err = verifyClustersCheckinsTable(db)
+	err = verifyClustersCheckinsTable(db.DB())
 	if err != nil {
 		log.Println("unable to verify " + clustersCheckinsTableName + " table")
 		return err
 	}
-	count, err = getTableCount(db, clustersCheckinsTableName)
+	count, err = getTableCount(db.DB(), clustersCheckinsTableName)
 	if err != nil {
 		log.Println("unable to get record count for " + clustersCheckinsTableName + " table")
 		return err

--- a/data/mem_db.go
+++ b/data/mem_db.go
@@ -3,8 +3,8 @@
 package data
 
 import (
-	"database/sql"
 	// this import registers "sqlite3" as a name you can provide to sql.Open
+	"github.com/jinzhu/gorm"
 	_ "github.com/mxk/go-sqlite/sqlite3"
 )
 
@@ -31,8 +31,8 @@ const (
 
 // NewMemDB returns a DB implementation that stores all data in-memory. The initial database
 // is empty, and is best used for testing.
-func NewMemDB() (*sql.DB, error) {
-	db, err := sql.Open(sqlite3Str, memStr)
+func NewMemDB() (*gorm.DB, error) {
+	db, err := gorm.Open(sqlite3Str, memStr)
 	if err != nil {
 		return nil, err
 	}

--- a/data/util.go
+++ b/data/util.go
@@ -15,7 +15,7 @@ func parseJSONComponent(jTxt sqlxTypes.JSONText) (types.ComponentVersion, error)
 	return *ret, nil
 }
 
-func parseDBVersions(versions []VersionsTable) ([]types.ComponentVersion, error) {
+func parseDBVersions(versions []versionsTable) ([]types.ComponentVersion, error) {
 	componentVersions := make([]types.ComponentVersion, len(versions))
 	for i, version := range versions {
 		cver, err := parseDBVersion(version)
@@ -27,19 +27,19 @@ func parseDBVersions(versions []VersionsTable) ([]types.ComponentVersion, error)
 	return componentVersions, nil
 }
 
-func parseDBVersion(version VersionsTable) (types.ComponentVersion, error) {
+func parseDBVersion(version versionsTable) (types.ComponentVersion, error) {
 	data := make(map[string]interface{})
-	if err := json.Unmarshal(version.data, &data); err != nil {
+	if err := json.Unmarshal(version.Data, &data); err != nil {
 		return types.ComponentVersion{}, err
 	}
 	return types.ComponentVersion{
 		Component: types.Component{
-			Name: version.componentName,
+			Name: version.ComponentName,
 		},
 		Version: types.Version{
-			Train:    version.train,
-			Version:  version.version,
-			Released: version.releaseTimestamp.String(),
+			Train:    version.Train,
+			Version:  version.Version,
+			Released: version.ReleaseTimestamp.String(),
 			Data:     data,
 		},
 	}, nil

--- a/data/version_test.go
+++ b/data/version_test.go
@@ -73,7 +73,7 @@ func TestVersionFromDBLatest(t *testing.T) {
 		}
 		componentVersions[i] = cv
 	}
-	cv, err := GetLatestVersion(sqliteDB, train, componentName)
+	cv, err := GetLatestVersion(sqliteDB.DB(), train, componentName)
 	assert.NoErr(t, err)
 	exCV := componentVersions[latestCVIdx]
 	assert.Equal(t, cv.Component.Name, exCV.Component.Name, "component name")
@@ -128,7 +128,7 @@ func TestVersionFromDBMultiLatest(t *testing.T) {
 		}
 	}
 
-	componentVersions, err := GetLatestVersions(memDB, componentAndTrainSlice)
+	componentVersions, err := GetLatestVersions(memDB.DB(), componentAndTrainSlice)
 	assert.NoErr(t, err)
 	assert.Equal(t, len(componentVersions), len(releaseTimes), "number of returned components")
 	for _, componentVersion := range componentVersions {

--- a/filter_by_age_test.go
+++ b/filter_by_age_test.go
@@ -46,9 +46,9 @@ func TestFilterByClusterAge(t *testing.T) {
 	cluster := types.Cluster{ID: uuid.New()}
 	srv := newServer(memDB)
 	defer srv.Close()
-	_, setErr := data.CheckInAndSetCluster(memDB, cluster.ID, cluster)
+	_, setErr := data.CheckInAndSetCluster(memDB.DB(), cluster.ID, cluster)
 	assert.NoErr(t, setErr)
-	_, checkInErr := data.CheckInCluster(memDB, cluster.ID, cluster)
+	_, checkInErr := data.CheckInCluster(memDB.DB(), cluster.ID, cluster)
 	assert.NoErr(t, checkInErr)
 	queryPairsMap := map[string]string{
 		rest.CheckedInBeforeQueryStringKey: filter.CheckedInBefore.Format(data.StdTimestampFmt),

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 515330aa934d0c01c8a1cddd2c1233963c21fe200419b015dee18aa0f557a0ee
-updated: 2016-04-27T16:30:57.793010673-07:00
+hash: e3a90fb19b6ccfcb231c44f0b2e41ed792304f46d1a8f566a78393ede44782c5
+updated: 2016-04-29T12:22:36.931573341-07:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c
@@ -105,6 +105,10 @@ imports:
   version: a8d44e7d8e4d532b6a27a02dd82abb31cc1b01bd
 - name: github.com/gorilla/mux
   version: 0eeaf8392f5b04950925b8a69fe70f110fa7cbfc
+- name: github.com/jinzhu/gorm
+  version: 5174cc5c242a728b435ea2be8a2f7f998e15429b
+- name: github.com/jinzhu/inflection
+  version: 3272df6c21d04180007eb3349844c89a3856bc25
 - name: github.com/jmespath/go-jmespath
   version: 0b12d6b521d83fc7f755e7cfc1b1fbdd35a01a74
 - name: github.com/jmoiron/sqlx

--- a/glide.yaml
+++ b/glide.yaml
@@ -19,3 +19,4 @@ import:
   subpackages:
   - sqlite3
 - package: github.com/pborman/uuid
+- package: github.com/jinzhu/gorm

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/deis/workflow-manager-api/data"
 	"github.com/deis/workflow-manager/types"
 	"github.com/gorilla/mux"
+	"github.com/jinzhu/gorm"
 )
 
 // ClustersCount route handler
@@ -75,7 +76,7 @@ func ClusterCheckin(db *sql.DB) http.Handler {
 }
 
 // GetVersion route handler
-func GetVersion(db *sql.DB) http.Handler {
+func GetVersion(db *gorm.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		routeParams := mux.Vars(r)
 		train := routeParams["train"]
@@ -124,7 +125,7 @@ func GetComponentTrainVersions(db *sql.DB) http.Handler {
 }
 
 // PublishVersion route handler
-func PublishVersion(db *sql.DB) http.Handler {
+func PublishVersion(db *gorm.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		componentVersion := types.ComponentVersion{}
 		err := json.NewDecoder(r.Body).Decode(&componentVersion)

--- a/server_test.go
+++ b/server_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -14,6 +13,7 @@ import (
 	"github.com/arschles/assert"
 	"github.com/deis/workflow-manager-api/data"
 	"github.com/deis/workflow-manager/types"
+	"github.com/jinzhu/gorm"
 )
 
 const (
@@ -22,7 +22,7 @@ const (
 	releaseTimeFormat = "2006-01-02T15:04:05Z"
 )
 
-func newServer(db *sql.DB) *httptest.Server {
+func newServer(db *gorm.DB) *httptest.Server {
 	// Routes consist of a path and a handler function.
 	return httptest.NewServer(getRoutes(db))
 }
@@ -199,7 +199,7 @@ func TestGetClusterByID(t *testing.T) {
 	srv := newServer(memDB)
 	defer srv.Close()
 	cluster := types.Cluster{ID: clusterID, FirstSeen: time.Now(), LastSeen: time.Now().Add(1 * time.Minute), Components: nil}
-	newCluster, err := data.CheckInAndSetCluster(memDB, clusterID, cluster)
+	newCluster, err := data.CheckInAndSetCluster(memDB.DB(), clusterID, cluster)
 	assert.NoErr(t, err)
 	resp, err := httpGet(srv, urlPath(1, "clusters", clusterID))
 	assert.NoErr(t, err)


### PR DESCRIPTION
This patch refactors the `(github.com/deis/workflow-manager-api/data).GetVersion` func to use [GORM](http://jinzhu.me/gorm/curd.html#query). In doing so, it touches other parts of the codebase to thread instances of `*gorm.DB` through the handlers to the data layer (instead of `*sql.DB`), and to change previous calls to `GetVersion` to pass the `*gorm.DB` instead of `*sql.DB`.

Note that this patch purposefully does not touch the `versions` table creation or maintenance logic, as that will come in another patch that includes schema and data integrity testing.

Contributes to #48 
