### PR TITLE
ref(handlers): use json encoders for responses

### DIFF
--- a/handlers/clusters_age_handler.go
+++ b/handlers/clusters_age_handler.go
@@ -2,8 +2,6 @@ package handlers
 
 import (
 	"database/sql"
-	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
 
@@ -30,11 +28,8 @@ func ClustersAge(db *sql.DB) http.Handler {
 			return
 		}
 		ret := clustersAgeResp{Data: clusters}
-		if err := json.NewEncoder(w).Encode(ret); err != nil {
-			log.Printf("Error json-encoding clusters (%s)", err)
-			http.Error(w, fmt.Sprintf("error encoding clusters (%s)", err), http.StatusInternalServerError)
-			return
+		if err := writeJSON(w, ret); err != nil {
+			log.Printf("ClustersAge json marshal error (%s)", err)
 		}
-
 	})
 }

--- a/handlers/get_latest_component_train_version.go
+++ b/handlers/get_latest_component_train_version.go
@@ -1,8 +1,8 @@
 package handlers
 
 import (
-	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 
 	"github.com/deis/workflow-manager-api/data"
@@ -30,9 +30,8 @@ func GetLatestComponentTrainVersion(db *gorm.DB) http.Handler {
 			http.Error(w, fmt.Sprintf("error getting component (%s)", err), http.StatusInternalServerError)
 			return
 		}
-		if json.NewEncoder(w).Encode(cv); err != nil {
-			http.Error(w, fmt.Sprintf("rrror getting latest component version (%s)", err), http.StatusInternalServerError)
-			return
+		if err := writeJSON(w, cv); err != nil {
+			log.Printf("GetLatestComponentTrainVersion json marshal error (%s)", err)
 		}
 	})
 }

--- a/handlers/get_latest_versions.go
+++ b/handlers/get_latest_versions.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 
 	"github.com/deis/workflow-manager-api/data"
@@ -64,9 +65,8 @@ func GetLatestVersions(db *sql.DB) http.Handler {
 		}
 
 		ret := ComponentVersionsJSONWrapper{Data: componentVersions}
-		if err := json.NewEncoder(w).Encode(ret); err != nil {
-			http.Error(w, "error encoding JSON", http.StatusInternalServerError)
-			return
+		if err := writeJSON(w, ret); err != nil {
+			log.Printf("GetLatestVersions json marshal failed (%s)", err)
 		}
 	})
 }

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -1,26 +1,54 @@
 package handlers
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/arschles/assert"
 )
 
 const (
-	jsonStr   = `{"this":"is json"}`
 	plainText = "this is plain text"
 )
 
 func TestWriteJSON(t *testing.T) {
-	json := []byte(jsonStr)
+	json := map[string]string{"this": "is json"}
+	const expected = `{"this":"is json"}`
 	w := httptest.NewRecorder()
-	writeJSON(json, w)
+	assert.NoErr(t, writeJSON(w, json))
 	assert.Equal(t, w.Code, http.StatusOK, "response code")
 	assert.Equal(t, w.HeaderMap.Get("Content-Type"), "application/json", "content type header")
 	assert.True(t, w.Body != nil, "response body was nil")
-	assert.Equal(t, string(w.Body.Bytes()), jsonStr, "response body")
+	assert.Equal(t, strings.TrimSpace(string(w.Body.Bytes())), expected, "response body")
+}
+
+func TestWriteJSONFail(t *testing.T) {
+	toEncode := map[string]interface{}{
+		"a": "b",
+		// funcs cannot be encoded as json. see https://godoc.org/encoding/json#Marshal
+		"c": func(i int) int { return i },
+	}
+	w := httptest.NewRecorder()
+	err := writeJSON(w, toEncode)
+	switch e := err.(type) {
+	case *json.UnsupportedTypeError:
+	default:
+		t.Fatalf("JSON encoding returned err (%s), expected an UnsupportedTypeError", e)
+	}
+
+	assert.Equal(t, w.Code, http.StatusInternalServerError, "response code")
+	assert.Equal(t, w.HeaderMap.Get("Content-Type"), "application/json", "content type header")
+	assert.True(t, w.Body != nil, "response body was nil")
+	var errBody struct {
+		Error     string `json:"error"`
+		ErrorType string `json:"error_type"`
+	}
+	assert.NoErr(t, json.NewDecoder(w.Body).Decode(&errBody))
+	assert.Equal(t, errBody.Error, err.Error(), "error string")
+	assert.Equal(t, errBody.ErrorType, "json", "error type")
 }
 
 func TestWritePlainText(t *testing.T) {


### PR DESCRIPTION
Also adds a standard JSON error response, and tests for it too.

Fixes https://github.com/deis/workflow-manager-api/issues/50
Fixes https://github.com/deis/workflow-manager-api/issues/51
