### PR TITLE
ref(data): write GetLatestVersions using gorm

### DIFF
--- a/data/util.go
+++ b/data/util.go
@@ -14,33 +14,3 @@ func parseJSONComponent(jTxt sqlxTypes.JSONText) (types.ComponentVersion, error)
 	}
 	return *ret, nil
 }
-
-func parseDBVersions(versions []versionsTable) ([]types.ComponentVersion, error) {
-	componentVersions := make([]types.ComponentVersion, len(versions))
-	for i, version := range versions {
-		cver, err := parseDBVersion(version)
-		if err != nil {
-			return nil, err
-		}
-		componentVersions[i] = cver
-	}
-	return componentVersions, nil
-}
-
-func parseDBVersion(version versionsTable) (types.ComponentVersion, error) {
-	data := make(map[string]interface{})
-	if err := json.Unmarshal(version.Data, &data); err != nil {
-		return types.ComponentVersion{}, err
-	}
-	return types.ComponentVersion{
-		Component: types.Component{
-			Name: version.ComponentName,
-		},
-		Version: types.Version{
-			Train:    version.Train,
-			Version:  version.Version,
-			Released: version.ReleaseTimestamp.String(),
-			Data:     data,
-		},
-	}, nil
-}

--- a/data/version_test.go
+++ b/data/version_test.go
@@ -25,7 +25,7 @@ func testComponentVersion() types.ComponentVersion {
 	}
 }
 
-func TestVersionFromDBRoundTrip(t *testing.T) {
+func TestVersionRoundTrip(t *testing.T) {
 	sqliteDB, err := NewMemDB()
 	assert.NoErr(t, err)
 	assert.NoErr(t, VerifyPersistentStorage(sqliteDB))
@@ -47,7 +47,7 @@ func TestVersionFromDBRoundTrip(t *testing.T) {
 	assert.Equal(t, getCVer.Version.Train, componentVersion.Version.Train, "version train")
 }
 
-func TestVersionFromDBLatest(t *testing.T) {
+func TestGetLatestVersion(t *testing.T) {
 	sqliteDB, err := NewMemDB()
 	assert.NoErr(t, err)
 	assert.NoErr(t, VerifyPersistentStorage(sqliteDB))
@@ -86,7 +86,7 @@ func TestVersionFromDBLatest(t *testing.T) {
 	assert.Equal(t, cv.Version.Data, exCV.Version.Data, "component version data")
 }
 
-func TestVersionFromDBMultiLatest(t *testing.T) {
+func TestGetLatestVersions(t *testing.T) {
 	memDB, err := NewMemDB()
 	assert.NoErr(t, err)
 	assert.NoErr(t, VerifyPersistentStorage(memDB))
@@ -128,7 +128,16 @@ func TestVersionFromDBMultiLatest(t *testing.T) {
 		}
 	}
 
-	componentVersions, err := GetLatestVersions(memDB.DB(), componentAndTrainSlice)
+	// now add a component & train that we aren't gonna filter for
+	cv := testComponentVersion()
+	cv.Component.Name = "invalid"
+	cv.Version.Train = "invalid"
+	cv.Version.Version = "invalid"
+	cv.Version.Released = time.Now().Format(released)
+	_, setErr := SetVersion(memDB, cv)
+	assert.NoErr(t, setErr)
+
+	componentVersions, err := GetLatestVersions(memDB, componentAndTrainSlice)
 	assert.NoErr(t, err)
 	assert.Equal(t, len(componentVersions), len(releaseTimes), "number of returned components")
 	for _, componentVersion := range componentVersions {

--- a/data/versions_table.go
+++ b/data/versions_table.go
@@ -3,6 +3,7 @@ package data
 import (
 	"database/sql"
 	"fmt"
+	"time"
 
 	"github.com/jinzhu/gorm"
 	"github.com/jmoiron/sqlx/types"
@@ -26,6 +27,17 @@ type versionsTable struct {
 	Version          string         `gorm:"column:version;index;unique"`
 	ReleaseTimestamp *Timestamp     `gorm:"column:release_timestamp;type:timestamp"`
 	Data             types.JSONText `gorm:"column:data;type:json"`
+}
+
+func newVersionsTable(versionID, componentName, train, version string, releaseTime time.Time, data []byte) versionsTable {
+	return versionsTable{
+		VersionID:        versionID,
+		ComponentName:    componentName,
+		Train:            train,
+		Version:          version,
+		ReleaseTimestamp: &Timestamp{Time: &releaseTime},
+		Data:             types.JSONText(data),
+	}
 }
 
 func (v versionsTable) TableName() string {

--- a/handlers/get_latest_versions.go
+++ b/handlers/get_latest_versions.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -9,6 +8,7 @@ import (
 
 	"github.com/deis/workflow-manager-api/data"
 	"github.com/deis/workflow-manager/types"
+	"github.com/jinzhu/gorm"
 )
 
 // SparseComponentInfo is the JSON compatible struct that holds limited data about a component
@@ -42,7 +42,7 @@ type ComponentVersionsJSONWrapper struct {
 }
 
 // GetLatestVersions is the handler for the POST /{apiVersion}/versions/latest endpoint
-func GetLatestVersions(db *sql.DB) http.Handler {
+func GetLatestVersions(db *gorm.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		reqStruct := new(SparseComponentAndTrainInfoJSONWrapper)
 		if err := json.NewDecoder(r.Body).Decode(reqStruct); err != nil {

--- a/server.go
+++ b/server.go
@@ -38,7 +38,7 @@ func main() {
 
 func getRoutes(db *gorm.DB) *mux.Router {
 	r := mux.NewRouter()
-	r.Handle("/{apiVersion}/versions/latest", handlers.GetLatestVersions(db.DB())).Methods("POST").
+	r.Handle("/{apiVersion}/versions/latest", handlers.GetLatestVersions(db)).Methods("POST").
 		Headers(handlers.ContentTypeHeaderKey, handlers.JSONContentType)
 	r.Handle("/{apiVersion}/versions/{train}/{component}", handlers.GetComponentTrainVersions(db.DB())).Methods("GET")
 	// Note: the following route must go before the route that ends with {version}, so that


### PR DESCRIPTION
Summary of changes:
- Moving `parseDBVersions` and `parseDBVersion` from `data/util.go` to `data/version.go`
- Changed the manually constructed query to use the gorm query builder in the `GetLatestVersions` func
  - Gorm struct mapping doesn't work because that query is returning the `release_timestamp` column twice, which throws it for a loop
- Checking the final error on row iteration in `GetLatestVersions`
- Changing version-related test functions to remove the redundant `FromDB` naming
- Add a component and version that the `GetLatestVersions` filter should eliminate in the `TestGetLatestVersions` test

Contributes to #48 
