### PR TITLE
fix(data): fix the cluster age filter

### DIFF
--- a/data/cluster.go
+++ b/data/cluster.go
@@ -90,10 +90,10 @@ func CheckInCluster(db *sql.DB, id string, cluster types.Cluster) (sql.Result, e
 // FilterClustersByAge returns a slice of clusters whose various time fields match the requirements
 // in the given filter. Note that the filter's requirements are a conjunction, not a disjunction
 func FilterClustersByAge(db *sql.DB, filter *ClusterAgeFilter) ([]types.Cluster, error) {
-	query := fmt.Sprintf(`SELECT DISTINCT clusters.*
+	query := fmt.Sprintf(`SELECT clusters.*
 		FROM clusters, clusters_checkins
 		WHERE clusters_checkins.cluster_id = clusters.cluster_id
-		GROUP BY clusters_checkins.cluster_id
+		GROUP BY clusters_checkins.cluster_id, clusters.cluster_id
 		HAVING MIN(clusters_checkins.created_at) > '%s'
 		AND MIN(clusters_checkins.created_at) < '%s'
 		AND MIN(clusters_checkins.created_at) > '%s'


### PR DESCRIPTION
The filter's underlying SQL query was using a `DISTINCT` to eliminate duplicate cluster checkins before running aggregate functions (like `MIN` and `MAX`) on all the checkins. That was wrong for the below reasons:

it was incorrect to use the `DISTINCT` keyword for a few reasons:
- Postgres required that the Primary Key of the clusters table was also in the `GROUP BY` statement
- The `DISTINCT` was eliminating rows that needed consideration by the aggregate functions below

Fixes #104 
