### PR TITLE
ref(data): rejiggering cluster time properties

### DIFF
--- a/data/cluster_test.go
+++ b/data/cluster_test.go
@@ -35,11 +35,11 @@ func newDB() (*gorm.DB, error) {
 	return db, nil
 }
 
-func testCluster() types.Cluster {
-	return types.Cluster{
-		ID:         clusterID,
-		Components: []types.ComponentVersion{testComponentVersion()},
-	}
+func testCluster() ClusterStateful {
+	cluster := ClusterStateful{}
+	cluster.ID = clusterID
+	cluster.Components = []types.ComponentVersion{testComponentVersion()}
+	return cluster
 }
 
 func TestClusterFromDBRoundTrip(t *testing.T) {
@@ -47,7 +47,7 @@ func TestClusterFromDBRoundTrip(t *testing.T) {
 	assert.NoErr(t, err)
 	cluster, err := GetCluster(sqliteDB, clusterID)
 	assert.True(t, err != nil, "error not returned when expected")
-	assert.Equal(t, cluster, types.Cluster{}, "returned cluster")
+	assert.Equal(t, cluster, ClusterStateful{}, "returned cluster")
 	expectedCluster := testCluster()
 	// the first time we invoke .CheckInAndSetCluster() it will create a new record
 	newCluster, err := CheckInAndSetCluster(sqliteDB, clusterID, expectedCluster)

--- a/data/util.go
+++ b/data/util.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"encoding/json"
+	"log"
 
 	"github.com/deis/workflow-manager/types"
 	sqlxTypes "github.com/jmoiron/sqlx/types"
@@ -13,4 +14,15 @@ func parseJSONComponent(jTxt sqlxTypes.JSONText) (types.ComponentVersion, error)
 		return types.ComponentVersion{}, err
 	}
 	return *ret, nil
+}
+
+// parseJSONCluster converts a JSON representation of a cluster
+// to a ClusterStateful type
+func parseJSONCluster(rawJSON []byte) (ClusterStateful, error) {
+	var cluster ClusterStateful
+	if err := json.Unmarshal(rawJSON, &cluster); err != nil {
+		log.Print(err)
+		return ClusterStateful{}, err
+	}
+	return cluster, nil
 }

--- a/filter_by_age_test.go
+++ b/filter_by_age_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/arschles/assert"
 	"github.com/deis/workflow-manager-api/data"
 	"github.com/deis/workflow-manager-api/rest"
-	"github.com/deis/workflow-manager/types"
 	"github.com/pborman/uuid"
 )
 
@@ -43,7 +42,8 @@ func TestFilterByClusterAge(t *testing.T) {
 	memDB, err := data.NewMemDB()
 	assert.NoErr(t, err)
 	assert.NoErr(t, data.VerifyPersistentStorage(memDB))
-	cluster := types.Cluster{ID: uuid.New()}
+	cluster := data.ClusterStateful{}
+	cluster.ID = uuid.New()
 	srv := newServer(memDB)
 	defer srv.Close()
 	_, setErr := data.CheckInAndSetCluster(memDB, cluster.ID, cluster)
@@ -69,7 +69,7 @@ func TestFilterByClusterAge(t *testing.T) {
 	defer resp.Body.Close()
 	assert.Equal(t, resp.StatusCode, http.StatusOK, "response code")
 	var respEnvelope struct {
-		Data []types.Cluster `json:"data"`
+		Data []data.ClusterStateful `json:"data"`
 	}
 	assert.NoErr(t, json.NewDecoder(resp.Body).Decode(&respEnvelope))
 	assert.Equal(t, len(respEnvelope.Data), 1, "length of the clusters list")

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,12 @@
 hash: e3a90fb19b6ccfcb231c44f0b2e41ed792304f46d1a8f566a78393ede44782c5
-updated: 2016-04-29T12:22:36.931573341-07:00
+updated: 2016-05-05T14:29:44.2006968-07:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c
 - name: github.com/arschles/assert
-  version: d21ecd4884be33397d1298c3738b2b4937c7f499
+  version: 5c22e2eba944d89ddd5c81b2c4175e64ee828503
 - name: github.com/aws/aws-sdk-go
-  version: 4acef85041b5e039cc17094885dd3ce93a7be290
+  version: d85fa529a99a833067e11c0a838b9db7a5d5ea71
   subpackages:
   - aws
   - aws/session
@@ -40,7 +40,7 @@ imports:
   subpackages:
   - spew
 - name: github.com/deis/workflow-manager
-  version: a21b95fc764d444a19a375bb1fe99a5c98a67432
+  version: 8acc51a8cae2f4a1e377ef2b961f2869cc01a671
   subpackages:
   - components
   - types
@@ -104,9 +104,9 @@ imports:
 - name: github.com/gorilla/context
   version: a8d44e7d8e4d532b6a27a02dd82abb31cc1b01bd
 - name: github.com/gorilla/mux
-  version: 0eeaf8392f5b04950925b8a69fe70f110fa7cbfc
+  version: 9c19ed558d5df4da88e2ade9c8940d742aef0e7e
 - name: github.com/jinzhu/gorm
-  version: 5174cc5c242a728b435ea2be8a2f7f998e15429b
+  version: bf413d67d3a25d4eeddb28541283fa6434d1cdb5
 - name: github.com/jinzhu/inflection
   version: 3272df6c21d04180007eb3349844c89a3856bc25
 - name: github.com/jmespath/go-jmespath
@@ -118,9 +118,9 @@ imports:
 - name: github.com/juju/ratelimit
   version: 772f5c38e468398c4511514f4f6aa9a4185bc0a0
 - name: github.com/kelseyhightower/envconfig
-  version: cea086319492c3940683ea5e122aa5de70a33923
+  version: 91921eb4cf999321cdbeebdba5a03555800d493b
 - name: github.com/lib/pq
-  version: 3cd0097429be7d611bb644ef85b42bfb102ceea4
+  version: dd3290b2f71a8b30bee8e4e75a337a825263d26f
   subpackages:
   - oid
 - name: github.com/matttproud/golang_protobuf_extensions

--- a/handlers/clusters_age_handler.go
+++ b/handlers/clusters_age_handler.go
@@ -6,13 +6,12 @@ import (
 	"net/http"
 
 	"github.com/deis/workflow-manager-api/data"
-	"github.com/deis/workflow-manager/types"
 )
 
 // ClustersAge is the handler for the GET /{apiVersion}/clusters/age endpoint
 func ClustersAge(db *sql.DB) http.Handler {
 	type clustersAgeResp struct {
-		Data []types.Cluster `json:"data"`
+		Data []data.ClusterStateful `json:"data"`
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		clusterAgeFilter, err := parseAgeQueryKeys(r)

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -48,13 +48,13 @@ func GetCluster(db *gorm.DB) http.Handler {
 func ClusterCheckin(db *gorm.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := mux.Vars(r)["id"]
-		cluster := types.Cluster{}
+		cluster := data.ClusterStateful{}
 		err := json.NewDecoder(r.Body).Decode(&cluster)
 		if err != nil {
 			log.Printf("Error decoding POST body JSON data (%s)", err)
 			return
 		}
-		var result types.Cluster
+		var result data.ClusterStateful
 		result, err = data.CheckInAndSetCluster(db, id, cluster)
 		if err != nil {
 			log.Printf("data.SetCluster error (%s)", err)

--- a/server_test.go
+++ b/server_test.go
@@ -198,14 +198,16 @@ func TestGetClusterByID(t *testing.T) {
 	assert.NoErr(t, data.VerifyPersistentStorage(memDB))
 	srv := newServer(memDB)
 	defer srv.Close()
-	cluster := types.Cluster{ID: clusterID, FirstSeen: time.Now(), LastSeen: time.Now().Add(1 * time.Minute), Components: nil}
+	cluster := data.ClusterStateful{}
+	cluster.ID = clusterID
+	cluster.Components = nil
 	newCluster, err := data.CheckInAndSetCluster(memDB, clusterID, cluster)
 	assert.NoErr(t, err)
 	resp, err := httpGet(srv, urlPath(1, "clusters", clusterID))
 	assert.NoErr(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, resp.StatusCode, 200, "response code")
-	decodedCluster := new(types.Cluster)
+	decodedCluster := new(data.ClusterStateful)
 	assert.NoErr(t, json.NewDecoder(resp.Body).Decode(decodedCluster))
 	assert.Equal(t, *decodedCluster, newCluster, "returned cluster")
 }
@@ -233,7 +235,7 @@ func TestPostClusters(t *testing.T) {
 	if resp.StatusCode != 200 {
 		t.Fatalf("Received non-200 response: %d", resp.StatusCode)
 	}
-	cluster := new(types.Cluster)
+	cluster := new(data.ClusterStateful)
 	if err := json.NewDecoder(resp.Body).Decode(cluster); err != nil {
 		t.Fatalf("error reading response body (%s)", err)
 	}


### PR DESCRIPTION
This depends on a change in github.com/deis/workflow-manager:

https://github.com/deis/workflow-manager/pull/36

Including the "FirstSeen" and "LastSeen" properties with every `Cluster` type usage means, in practice, that we're passing around and storing the zero value for those properties, which is inefficient, wasteful, and misleading.

This PR introduces a `ClusterStateful` type that is native to this codebase, but which inherits from `workflow-manager/types.Cluster` for its non-stateful properties.

contributes to #115
fixes #68
