### PR TITLE
ref(data,handlers,server.go): rewrite GetVersionsList using gorm

### DIFF
--- a/data/data.go
+++ b/data/data.go
@@ -83,21 +83,6 @@ func getDBRecord(db *sql.DB, table string, keys []string, vals []string) *sql.Ro
 	return db.QueryRow(query)
 }
 
-// getDBRecords is a convenience that executes a simple "SELECT *" SQL query against
-// a passed-in db reference, accepting an arbitrary number of keys(table fields)/vals
-func getDBRecords(db *sql.DB, table string, keys []string, vals []string) (*sql.Rows, error) {
-	sliceEqualize(&keys, &vals)
-	query := fmt.Sprintf("SELECT * FROM %s", table)
-	for i, key := range keys {
-		if i == 0 {
-			query += fmt.Sprintf(" WHERE %s = '%s'", key, vals[i])
-		} else {
-			query += fmt.Sprintf(" AND %s = '%s'", key, vals[i])
-		}
-	}
-	return db.Query(query)
-}
-
 // sliceEqualize is a convenience that ensures two slices of strings have equal lengths
 // if not, the larger slice's elements that exceed the boundary of the smaller are stripped
 func sliceEqualize(slice1 *[]string, slice2 *[]string) {

--- a/data/version.go
+++ b/data/version.go
@@ -200,25 +200,11 @@ func GetVersion(db *gorm.DB, cV types.ComponentVersion) (types.ComponentVersion,
 }
 
 // GetVersionsList retrieves a list of version records from the DB that match a given train & component
-func GetVersionsList(db *sql.DB, train string, component string) ([]types.ComponentVersion, error) {
-	rows, err := getDBRecords(db, versionsTableName,
-		[]string{versionsTableTrainKey, versionsTableComponentNameKey},
-		[]string{train, component})
-	if err != nil {
-		return nil, err
-	}
-	rowsResult := []versionsTable{}
-	var row versionsTable
-	defer rows.Close()
-	for rows.Next() {
-		//TODO: sql.NullString is to pass tests, not for production
-		var s sql.NullString
-		err = rows.Scan(&s, &row.ComponentName,
-			&row.Train, &row.Version, &row.ReleaseTimestamp, &row.Data)
-		if err != nil {
-			return nil, err
-		}
-		rowsResult = append(rowsResult, row)
+func GetVersionsList(db *gorm.DB, train string, component string) ([]types.ComponentVersion, error) {
+	var rowsResult []versionsTable
+	resDB := db.Where(&versionsTable{Train: train, ComponentName: component}).Find(&rowsResult)
+	if resDB.Error != nil {
+		return nil, resDB.Error
 	}
 	componentVersions, err := parseDBVersions(rowsResult)
 	if err != nil {

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -2,7 +2,6 @@ package handlers
 
 // handler echoes the HTTP request.
 import (
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -90,7 +89,7 @@ func GetVersion(db *gorm.DB) http.Handler {
 }
 
 // GetComponentTrainVersions route handler
-func GetComponentTrainVersions(db *sql.DB) http.Handler {
+func GetComponentTrainVersions(db *gorm.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		routeParams := mux.Vars(r)
 		train := routeParams["train"]

--- a/server.go
+++ b/server.go
@@ -40,7 +40,7 @@ func getRoutes(db *gorm.DB) *mux.Router {
 	r := mux.NewRouter()
 	r.Handle("/{apiVersion}/versions/latest", handlers.GetLatestVersions(db)).Methods("POST").
 		Headers(handlers.ContentTypeHeaderKey, handlers.JSONContentType)
-	r.Handle("/{apiVersion}/versions/{component}/{train}", handlers.GetComponentTrainVersions(db.DB())).Methods("GET")
+	r.Handle("/{apiVersion}/versions/{component}/{train}", handlers.GetComponentTrainVersions(db)).Methods("GET")
 	// Note: the following route must go before the route that ends with {version}, so that
 	// Gorilla mux always routes the static "latest" route to the appropriate handler, and "latest"
 	// doesn't get interpreted as a {version}


### PR DESCRIPTION
This patch also removes the getDBRecords func, which is now unused after this change

Contributes to #48 
