### PR TITLE
chore(glide): remove obsolete deps

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,6 @@
 hash: e3a90fb19b6ccfcb231c44f0b2e41ed792304f46d1a8f566a78393ede44782c5
-updated: 2016-05-05T14:29:44.2006968-07:00
+updated: 2016-05-06T12:00:02.597792828-07:00
 imports:
-- name: bitbucket.org/ww/goautoneg
-  version: 75cd24fc2f2c
 - name: github.com/arschles/assert
   version: 5c22e2eba944d89ddd5c81b2c4175e64ee828503
 - name: github.com/aws/aws-sdk-go
@@ -29,78 +27,13 @@ imports:
   - private/protocol/query/queryutil
   - private/protocol/xml/xmlutil
   - private/protocol/rest
-- name: github.com/beorn7/perks
-  version: b965b613227fddccbfffe13eae360ed3fa822f8d
-  subpackages:
-  - quantile
-- name: github.com/blang/semver
-  version: 31b736133b98f26d5e078ec9eb591666edfd091f
-- name: github.com/davecgh/go-spew
-  version: 3e6e67c4dcea3ac2f25fd4731abc0e1deaf36216
-  subpackages:
-  - spew
 - name: github.com/deis/workflow-manager
   version: 8acc51a8cae2f4a1e377ef2b961f2869cc01a671
   subpackages:
   - components
   - types
-  - config
-  - data
-- name: github.com/docker/docker
-  version: 2b27fe17a1b3fb8472fde96d768fa70996adf201
-  subpackages:
-  - pkg/jsonmessage
-  - pkg/mount
-  - pkg/parsers
-  - pkg/symlink
-  - pkg/term
-  - pkg/timeutils
-  - pkg/units
-- name: github.com/docker/libcontainer
-  version: 5dc7ba0f24332273461e45bc49edcb4d5aa6c44c
-  subpackages:
-  - cgroups/fs
-  - configs
-  - cgroups
-  - system
-- name: github.com/emicklei/go-restful
-  version: 1f9a0ee00ff93717a275e15b30cf7df356255877
-  subpackages:
-  - swagger
-  - log
-- name: github.com/ghodss/yaml
-  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-ini/ini
   version: 12f418cc7edc5a618a51407b7ac1f1f512139df3
-- name: github.com/golang/glog
-  version: 44145f04b68cf362d9c4df2182967c2275eaefed
-- name: github.com/golang/protobuf
-  version: 7f07925444bb51fa4cf9dfe6f7661876f8852275
-  subpackages:
-  - proto
-- name: github.com/google/cadvisor
-  version: a8085bf9276c22f16dbcd7aa56f0d4d0626a0b2e
-  subpackages:
-  - api
-  - cache/memory
-  - collector
-  - container
-  - events
-  - fs
-  - healthz
-  - http
-  - info/v1
-  - info/v2
-  - manager
-  - metrics
-  - pages
-  - storage
-  - summary
-  - utils
-  - validate
-  - version
-- name: github.com/google/gofuzz
-  version: bbcb9da2d746f8bdbd6a936686a0a6067ada0ec5
 - name: github.com/gorilla/context
   version: a8d44e7d8e4d532b6a27a02dd82abb31cc1b01bd
 - name: github.com/gorilla/mux
@@ -115,98 +48,14 @@ imports:
   version: 398dd5876282499cdfd4cb8ea0f31a672abe9495
   subpackages:
   - types
-- name: github.com/juju/ratelimit
-  version: 772f5c38e468398c4511514f4f6aa9a4185bc0a0
-- name: github.com/kelseyhightower/envconfig
-  version: 91921eb4cf999321cdbeebdba5a03555800d493b
 - name: github.com/lib/pq
   version: dd3290b2f71a8b30bee8e4e75a337a825263d26f
   subpackages:
   - oid
-- name: github.com/matttproud/golang_protobuf_extensions
-  version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
-  subpackages:
-  - pbutil
 - name: github.com/mxk/go-sqlite
   version: 167da9432e1f4602e95ea67b67051cfa34412e3f
   subpackages:
   - sqlite3
 - name: github.com/pborman/uuid
-  version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
-- name: github.com/prometheus/client_golang
-  version: 3b78d7a77f51ccbc364d4bc170920153022cfd08
-  subpackages:
-  - prometheus
-- name: github.com/prometheus/client_model
-  version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
-  subpackages:
-  - go
-- name: github.com/prometheus/common
-  version: ef7a9a5fb138aa5d3a19988537606226869a0390
-  subpackages:
-  - expfmt
-  - model
-- name: github.com/prometheus/procfs
-  version: 490cc6eb5fa45bf8a8b7b73c8bc82a8160e8531d
-- name: github.com/satori/go.uuid
-  version: f9ab0dce87d815821e221626b772e3475a0d2749
-- name: github.com/spf13/pflag
-  version: 8e7dc108ab3a1ab6ce6d922bbaff5657b88e8e49
-- name: golang.org/x/crypto
-  version: c84e1f8e3a7e322d497cd16c0e8a13c7e127baf3
-  subpackages:
-  - ssh
-- name: golang.org/x/net
-  version: c2528b2dd8352441850638a8bb678c2ad056fd3e
-  subpackages:
-  - context
-  - html
-  - websocket
-- name: gopkg.in/yaml.v2
-  version: d466437aa4adc35830964cffc5b5f262c63ddcb4
-- name: k8s.io/kubernetes
-  version: a8af33dc07ee08defa2d503f81e7deea32dd1d3b
-  subpackages:
-  - client/unversioned
-  - labels
-  - api
-  - pkg
-  - pkg/api
-  - pkg/client/unversioned
-  - pkg/labels
-  - pkg/api/errors
-  - pkg/api/meta
-  - pkg/api/resource
-  - pkg/api/unversioned
-  - pkg/auth/user
-  - pkg/conversion
-  - pkg/fields
-  - pkg/runtime
-  - pkg/types
-  - pkg/util
-  - pkg/util/rand
-  - pkg/util/sets
-  - pkg/api/install
-  - pkg/api/latest
-  - pkg/api/validation
-  - pkg/apis/extensions
-  - pkg/apis/extensions/install
-  - pkg/client/metrics
-  - pkg/conversion/queryparams
-  - pkg/util/wait
-  - pkg/version
-  - pkg/watch
-  - pkg/watch/json
-  - pkg/util/fielderrors
-  - pkg/util/validation
-  - pkg/util/errors
-  - third_party/forked/reflect
-  - pkg/util/yaml
-  - pkg/api/registered
-  - pkg/api/util
-  - pkg/api/v1
-  - pkg/capabilities
-  - pkg/apis/extensions/v1beta1
-- name: speter.net/go/exp/math/dec/inf
-  version: 42ca6cd68aa922bc3f32f1e056e61b65945d9ad7
+  version: c55201b036063326c5b1b89ccfe45a184973d073
 devImports: []


### PR DESCRIPTION
including big ones like github.com/docker/docker and k8s.io/kubernetes!
