### PR TITLE
ref(travis): enable prod deploys, decompose travis scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,11 @@ install:
 script:
   - make test build docker-build
 deploy:
-  provider: script
-  script: _scripts/deploy.sh
-  on:
-    branch: master
+  - provider: script
+    script: _scripts/stage.sh
+    on:
+      branch: master
+  - provider: script
+    script: _scripts/deploy.sh
+    on:
+      tags: true

--- a/_scripts/deploy.sh
+++ b/_scripts/deploy.sh
@@ -1,17 +1,13 @@
 #!/usr/bin/env bash
 #
-# Build and push Docker images to Docker Hub and quay.io.
+# Deploy to production
 #
 
-cd "$(dirname "$0")" || exit 1
-
-export IMAGE_PREFIX=deisci
-docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-DEIS_REGISTRY='' make -C .. docker-push
-docker login -e="$QUAY_EMAIL" -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" quay.io
-DEIS_REGISTRY=quay.io/ make -C .. docker-build docker-push
-
-# download deis CLI & deploy to deis
-curl -sSL http://deis.io/deis-cli/install-v2.sh | bash
-./deis login --username=$DEIS_USERNAME --password=$DEIS_PASSWORD ${DEIS_URL}
-DEIS_BINARY_NAME=./_scripts/deis DEIS_APP_NAME=${DEIS_APP_NAME} make -C .. deploy-to-deis
+export IMAGE_PREFIX=deis
+# publish app image to repositories
+source publish.sh
+# download deis CLI
+source get-deis.sh
+# deploy to production
+./deis login --username=$DEIS_PROD_USERNAME --password=$DEIS_PROD_PASSWORD ${DEIS_PROD_URL}
+DEIS_BINARY_NAME=./_scripts/deis DEIS_APP_NAME=${DEIS_PROD_APP_NAME} make -C .. deploy-to-deis

--- a/_scripts/get-deis.sh
+++ b/_scripts/get-deis.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#
+# Download the deis client package and install to cwd
+#
+curl -sSL http://deis.io/deis-cli/install-v2.sh | bash

--- a/_scripts/publish.sh
+++ b/_scripts/publish.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# Build and push Docker images to Docker Hub and quay.io.
+#
+
+cd "$(dirname "$0")" || exit 1
+
+docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+DEIS_REGISTRY='' make -C .. docker-push
+docker login -e="$QUAY_EMAIL" -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" quay.io
+DEIS_REGISTRY=quay.io/ make -C .. docker-build docker-push

--- a/_scripts/stage.sh
+++ b/_scripts/stage.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# Stage a build
+#
+
+export IMAGE_PREFIX=deisci
+# publish app image to repositories
+source publish.sh
+# download deis CLI
+source get-deis.sh
+# deploy to production
+./deis login --username=$DEIS_STAGING_USERNAME --password=$DEIS_STAGING_PASSWORD ${DEIS_STAGING_URL}
+DEIS_BINARY_NAME=./_scripts/deis DEIS_APP_NAME=${DEIS_STAGING_APP_NAME} make -C .. deploy-to-deis


### PR DESCRIPTION
This travis refactor does the following:
- now using multiple travis `deploy` providers to do the following:
  - deploy to prod on a tag
  - deploy to staging on master branch transitions
- using prod/staging specific env vars (travis updated)
- prod builds go to `deis` image bucket, staging builds go to `deisci` image bucket
- decomposed bash scripts to prevent code duplication
