### PR TITLE
chore(travis): only scripts called from travis need the cwd foo

### DIFF
--- a/_scripts/get-deis.sh
+++ b/_scripts/get-deis.sh
@@ -3,6 +3,4 @@
 # Download the deis client package and install to cwd
 #
 
-cd "$(dirname "$0")" || exit 1
-
 curl -sSL http://deis.io/deis-cli/install-v2.sh | bash

--- a/_scripts/publish.sh
+++ b/_scripts/publish.sh
@@ -3,8 +3,6 @@
 # Build and push Docker images to Docker Hub and quay.io.
 #
 
-cd "$(dirname "$0")" || exit 1
-
 docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
 DEIS_REGISTRY='' make -C .. docker-push
 docker login -e="$QUAY_EMAIL" -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" quay.io


### PR DESCRIPTION
travis currently calls stage.sh and deploy.sh, so we leave the cd to script directory there, but remove on sourced scripts
