### PR TITLE
chore(make): build before docker-build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ sudo: required
 install:
   - make bootstrap
 script:
-  - make test build docker-build
+  - make test docker-build
 deploy:
   provider: script
   script: _scripts/deploy.sh

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ test:
 test-native:
 	go test -tags=testonly $$(glide nv)
 
-docker-build:
+docker-build: build
 	docker build --rm -t ${IMAGE} rootfs
 	docker tag ${IMAGE} ${MUTABLE_IMAGE}
 


### PR DESCRIPTION
the docker-build make target assumes pre-built artifacts already exist, so we should just insert "make build" as a pre-step for "make docker-build"
